### PR TITLE
Enable TypeScript linting

### DIFF
--- a/lib/extensionConfiguration.js
+++ b/lib/extensionConfiguration.js
@@ -20,7 +20,7 @@ const { generateTrackerAllowlistRules } = require('./trackerAllowlist')
  * @param {number} [startingRuleId = 1]
  *   Rule ID for the generated declarativeNetRequest rules to start from. Rule
  *   IDs are incremented sequentially from the starting point.
- * @return {generateExtensionConfigurationRulesetResult}
+ * @return {Promise<generateExtensionConfigurationRulesetResult>}
  */
 
 async function generateExtensionConfigurationRuleset (

--- a/lib/trackerAllowlist.js
+++ b/lib/trackerAllowlist.js
@@ -19,6 +19,13 @@ const CEILING_PRIORITY = 20100
 const MAXIMUM_RULES_PER_TRACKER_ENTRY = (CEILING_PRIORITY - BASELINE_PRIORITY) /
                                             PRIORITY_INCREMENT
 
+/**
+ * Generator to produce the declarativeNetRequest rules and corresponding match
+ * details for the given trackerAllowlist configuration.
+ * @param {object} extensionConfiguration
+ *   The extension configuration.
+ * @return {Generator<[import('./trackerBlocking').DNRRule, object]>}
+ */
 function* generateTrackerAllowlistRules ({ features: { trackerAllowlist } }) {
     // No allowlisted trackers.
     if (!trackerAllowlist ||
@@ -61,7 +68,7 @@ function* generateTrackerAllowlistRules ({ features: { trackerAllowlist } }) {
         }
         if (trackerEntryRules.length > MAXIMUM_RULES_PER_TRACKER_ENTRY) {
             throw new Error(
-                'Too many allowlist rules for tracker domain:', trackerDomain
+                'Too many allowlist rules for tracker domain: ' + trackerDomain
             )
         }
 

--- a/lib/trackerBlocking.js
+++ b/lib/trackerBlocking.js
@@ -66,11 +66,61 @@ const resourceTypes = new Set([
     'webtransport', 'webbundle', 'other'
 ])
 
+/**
+ * Unfortunately it's a little tricky to interact with TypeScript Enum types
+ * from JavaScript code, assigning the literal value (even if valid) results in
+ * a type coercion error. As a workaround, use the backtick syntax to get the
+ * possible enum values and then use those values to declare new types.
+ * Hopefully, interacting with Enums will get easier in the future and this can
+ * be removed.
+ * @typedef {`${chrome.declarativeNetRequest.DomainType}`} DomainType
+ * @typedef {`${chrome.declarativeNetRequest.RequestMethod}`} RequestMethod
+ * @typedef {`${chrome.declarativeNetRequest.ResourceType}`} ResourceType
+ * @typedef {`${chrome.declarativeNetRequest.RuleActionType}`} DNRRuleActionType
+ * @typedef {Omit<chrome.declarativeNetRequest.RuleAction,
+ *                'type' | 'redirect' | 'requestHeaders' | 'responseHeaders'> &
+ *           {type: DNRRuleActionType, redirect?: object,
+ *            requestHeaders?: object, responseHeaders?: object}} DNRRuleAction
+ * @typedef {Omit<chrome.declarativeNetRequest.RuleCondition,
+ *               'domainType' | 'excludedRequestMethods' |
+ *               'excludedResourceTypes' | 'requestMethods' |
+ *               'resourceTypes'> &
+ *           {domainType?: DomainType, excludedRequestMethods?: RequestMethod[],
+ *            excludedResourceTypes?: ResourceType[],
+ *            requestMethods?: RequestMethod[],
+ *            resourceTypes?: ResourceType[]}} DNRRuleCondition
+ * @typedef {Omit<chrome.declarativeNetRequest.Rule,
+ *                'id' | 'action' | 'condition'> &
+ *           {id?: number, action: DNRRuleAction,
+              condition: DNRRuleCondition}} DNRRule
+ */
+
+/**
+ * @typedef {object} generateDNRRuleDetails
+ * @property {number} [id]
+ * @property {number} priority
+ * @property {DNRRuleActionType} actionType
+ * @property {string} [urlFilter]
+ * @property {string} [regexFilter]
+ * @property {ResourceType[]} [resourceTypes]
+ * @property {string[]} requestDomains
+ * @property {string[]} [excludedRequestDomains]
+ * @property {string[]} [initiatorDomains]
+ * @property {string[]} [excludedInitiatorDomains]
+ * @property {boolean} [matchCase]
+ */
+
+/**
+ * Generates a declarativeNetRequest rule with the given details.
+ * @param {generateDNRRuleDetails} ruleDetails
+ * @return {DNRRule}
+ */
 function generateDNRRule ({
     id, priority, actionType, urlFilter, regexFilter, resourceTypes,
     requestDomains, excludedRequestDomains, initiatorDomains,
     excludedInitiatorDomains, matchCase = false
 }) {
+    /** @type {DNRRule} */
     const dnrRule = {
         priority,
         action: {
@@ -479,7 +529,7 @@ async function generateDNRRulesForTrackerEntry (
 
     if (trackerEntryRules.length * TRACKER_RULE_PRIORITY_INCREMENT >
         MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT) {
-        throw new Error('Too many rules for tracker domain:', trackerDomain)
+        throw new Error('Too many rules for tracker domain:' + trackerDomain)
     }
 
     // Iterate through the tracker entry's rules backwards, since rules for a
@@ -628,9 +678,9 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
 
 /**
  * @typedef {object} generateTrackerBlockingRulesetResult
- * @property {object[]} ruleset
+ * @property {DNRRule[]} ruleset
  *   The generated Tracker Blocking declarativeNetRequest ruleset.
- * @property {number[]} trackerDomainByRuleId
+ * @property {(null|string)[]} trackerDomainByRuleId
  *   Rule ID -> tracker domain mapping. Useful for translating a rule match to
  *   a tracker entry.
  */
@@ -646,7 +696,7 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
  * @param {number} [startingRuleId = 1]
  *   Rule ID for the generated declarativeNetRequest rules to start from. Rule
  *   IDs are incremented sequentially from the starting point.
- * @return {generateTrackerBlockingRulesetResult}
+ * @return {Promise<generateTrackerBlockingRulesetResult>}
  */
 async function generateTrackerBlockingRuleset (
     tds, isRegexSupported, startingRuleId = 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,14 @@
             "license": "Apache-2.0",
             "devDependencies": {
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445",
+                "@types/chrome": "0.0.195",
+                "@types/mocha": "^9.1.1",
+                "@types/puppeteer": "5.4.6",
                 "eslint": "7.32.0",
                 "eslint-config-standard": "16.0.3",
                 "mocha": "9.2.2",
-                "puppeteer": "15.1.1"
+                "puppeteer": "15.1.1",
+                "typescript": "4.7.3"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -166,6 +170,37 @@
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
         },
+        "node_modules/@types/chrome": {
+            "version": "0.0.195",
+            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.195.tgz",
+            "integrity": "sha512-kmFh1xx7ehXoOVl6OjEBxmiYaquhxCaILjFGwPbW6xwbqzwDKCte+Mzl99aNWg3EP1B4rKVUuRm1vBsiRYks5g==",
+            "dev": true,
+            "dependencies": {
+                "@types/filesystem": "*",
+                "@types/har-format": "*"
+            }
+        },
+        "node_modules/@types/filesystem": {
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+            "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/filewriter": "*"
+            }
+        },
+        "node_modules/@types/filewriter": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+            "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
+            "dev": true
+        },
+        "node_modules/@types/har-format": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+            "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+            "dev": true
+        },
         "node_modules/@types/json5": {
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -173,12 +208,26 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/@types/mocha": {
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+            "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+            "dev": true
+        },
         "node_modules/@types/node": {
             "version": "17.0.31",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
             "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
+            "dev": true
+        },
+        "node_modules/@types/puppeteer": {
+            "version": "5.4.6",
+            "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.6.tgz",
+            "integrity": "sha512-98Kghehs7+/GD9b56qryhqdqVCXUTbetTv3PlvDnmFRTHQH0j9DIp1f7rkAW3BAj4U3yoeSEQnKgdW8bDq0Y0Q==",
             "dev": true,
-            "optional": true
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/yauzl": {
             "version": "2.10.0",
@@ -3101,6 +3150,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/typescript": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+            "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -3459,6 +3521,37 @@
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
         },
+        "@types/chrome": {
+            "version": "0.0.195",
+            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.195.tgz",
+            "integrity": "sha512-kmFh1xx7ehXoOVl6OjEBxmiYaquhxCaILjFGwPbW6xwbqzwDKCte+Mzl99aNWg3EP1B4rKVUuRm1vBsiRYks5g==",
+            "dev": true,
+            "requires": {
+                "@types/filesystem": "*",
+                "@types/har-format": "*"
+            }
+        },
+        "@types/filesystem": {
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+            "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+            "dev": true,
+            "requires": {
+                "@types/filewriter": "*"
+            }
+        },
+        "@types/filewriter": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+            "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
+            "dev": true
+        },
+        "@types/har-format": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+            "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+            "dev": true
+        },
         "@types/json5": {
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -3466,12 +3559,26 @@
             "dev": true,
             "peer": true
         },
+        "@types/mocha": {
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+            "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+            "dev": true
+        },
         "@types/node": {
             "version": "17.0.31",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
             "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
+            "dev": true
+        },
+        "@types/puppeteer": {
+            "version": "5.4.6",
+            "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.6.tgz",
+            "integrity": "sha512-98Kghehs7+/GD9b56qryhqdqVCXUTbetTv3PlvDnmFRTHQH0j9DIp1f7rkAW3BAj4U3yoeSEQnKgdW8bDq0Y0Q==",
             "dev": true,
-            "optional": true
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/yauzl": {
             "version": "2.10.0",
@@ -5606,6 +5713,12 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true
+        },
+        "typescript": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+            "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
             "dev": true
         },
         "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -6,14 +6,20 @@
     "repository": "duckduckgo/ddg2dnr",
     "devDependencies": {
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445",
+        "@types/chrome": "0.0.195",
+        "@types/mocha": "^9.1.1",
+        "@types/puppeteer": "5.4.6",
         "eslint": "7.32.0",
         "eslint-config-standard": "16.0.3",
         "mocha": "9.2.2",
-        "puppeteer": "15.1.1"
+        "puppeteer": "15.1.1",
+        "typescript": "4.7.3"
     },
     "scripts": {
         "extension-configuration": "node cli.js extension-configuration",
-        "lint": "eslint . --ext .js",
+        "eslint": "eslint . --ext .js",
+        "tsc": "tsc",
+        "lint": "npm run eslint && npm run tsc",
         "smarter-encryption": "node cli.js smarter-encryption",
         "test": "mocha",
         "tracker-blocking": "node cli.js tracker-blocking"

--- a/test/extensionConfiguration.js
+++ b/test/extensionConfiguration.js
@@ -26,14 +26,17 @@ describe('generateExtensionConfigurationRuleset', () => {
 
     it('should notice missing isRegexSupported argument', async () => {
         await assert.rejects(() =>
+            // @ts-expect-error - Missing isRegexSupported argument.
             generateExtensionConfigurationRuleset({
                 features: {}
             })
         )
         await assert.rejects(() =>
-            generateExtensionConfigurationRuleset({
-                features: {}
-            }, 3)
+            generateExtensionConfigurationRuleset(
+                { features: {} },
+                // @ts-expect-error - Invalid isRegexSupported argument.
+                3
+            )
         )
         await assert.doesNotReject(() =>
             generateExtensionConfigurationRuleset({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "moduleResolution": "node",
+    "alwaysStrict": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "strictNullChecks": true,
+    "maxNodeModuleJsDepth": 0
+  },
+  "include": [
+      "*.js",
+      "**/*.js"
+  ],
+  "exclude": [
+      "node_modules",
+      "puppeteerInterface.js"
+  ],
+  "types": [
+      "chrome"
+  ]
+}


### PR DESCRIPTION
While we're not switching to TypeScript, we can still make use of
TypeScript linting with JSDoc comments. That should help reduce typos
and similar bugs from sneaking into the codebase.

Note: In the future it would be nice to enable TypeScript linting for
      puppeteerInterface.js and enable the "noImplicitAny" option.