### PR TITLE
Migrate to ES modules

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,12 +1,13 @@
-const fs = require('fs')
-const process = require('process')
+import * as fs from 'fs'
+import * as process from 'process'
 
-const { PuppeteerInterface } = require('./puppeteerInterface')
+import { PuppeteerInterface } from './puppeteerInterface.js'
 
-const { generateSmarterEncryptionRuleset } = require('./lib/smarterEncryption')
-const { generateTrackerBlockingRuleset } = require('./lib/trackerBlocking')
-const { generateExtensionConfigurationRuleset } =
-      require('./lib/extensionConfiguration')
+import { generateSmarterEncryptionRuleset } from './lib/smarterEncryption.js'
+import { generateTrackerBlockingRuleset } from './lib/trackerBlocking.js'
+import {
+    generateExtensionConfigurationRuleset
+} from './lib/extensionConfiguration.js'
 
 const [command, ...args] = process.argv.slice(2)
 

--- a/lib/extensionConfiguration.js
+++ b/lib/extensionConfiguration.js
@@ -1,6 +1,4 @@
-/** @module extensionConfiguration */
-
-const { generateTrackerAllowlistRules } = require('./trackerAllowlist')
+import { generateTrackerAllowlistRules } from './trackerAllowlist.js'
 
 /**
  * @typedef {object} generateExtensionConfigurationRulesetResult
@@ -22,8 +20,7 @@ const { generateTrackerAllowlistRules } = require('./trackerAllowlist')
  *   IDs are incremented sequentially from the starting point.
  * @return {Promise<generateExtensionConfigurationRulesetResult>}
  */
-
-async function generateExtensionConfigurationRuleset (
+export async function generateExtensionConfigurationRuleset (
     extensionConfig, isRegexSupported, startingRuleId = 1
 ) {
     if (typeof isRegexSupported !== 'function') {
@@ -46,6 +43,3 @@ async function generateExtensionConfigurationRuleset (
 
     return { ruleset, matchDetailsByRuleId }
 }
-
-exports.generateExtensionConfigurationRuleset =
-    generateExtensionConfigurationRuleset

--- a/lib/smarterEncryption.js
+++ b/lib/smarterEncryption.js
@@ -1,8 +1,6 @@
-/** @module smarterEncryption */
+import { storeInLookup } from './utils.js'
 
-const { storeInLookup } = require('./utils')
-
-const SMARTER_ENCRYPTION_PRIORITY = 100000
+export const SMARTER_ENCRYPTION_PRIORITY = 100000
 
 function generateRegexFilter (subdomainCount, matchWwwSubdomain) {
     return (
@@ -54,7 +52,7 @@ function generateRule (id, subdomainCount, domains, matchWwwSubdomain) {
  * @return {Object[]}
  *   The declarativeNetRequest rules.
  */
-function generateSmarterEncryptionRuleset (domains, startingRuleId = 1) {
+export function generateSmarterEncryptionRuleset (domains, startingRuleId = 1) {
     const domainsBySubdomainCount = new Map()
     const domainsWithOptionalWwwBySubdomainCount = new Map()
 
@@ -129,6 +127,3 @@ function generateSmarterEncryptionRuleset (domains, startingRuleId = 1) {
 
     return rules
 }
-
-exports.SMARTER_ENCRYPTION_PRIORITY = SMARTER_ENCRYPTION_PRIORITY
-exports.generateSmarterEncryptionRuleset = generateSmarterEncryptionRuleset

--- a/lib/trackerAllowlist.js
+++ b/lib/trackerAllowlist.js
@@ -1,32 +1,30 @@
-/** @module trackerAllowlist */
-
-const { storeInLookup } = require('./utils')
-const {
-    getTrackerEntryDomain, generateDNRRule
-} = require('./trackerBlocking')
+import { storeInLookup } from './utils.js'
+import { getTrackerEntryDomain, generateDNRRule } from './trackerBlocking.js'
 
 // Priority that the Tracker Blocking Allowlist declarativeNetRequest rules
 // start from.
-const BASELINE_PRIORITY = 20000
+export const BASELINE_PRIORITY = 20000
 
-const PRIORITY_INCREMENT = 1
+export const PRIORITY_INCREMENT = 1
 
 // Highest possible priority Tracker Blocking Allowlist declarativeNetRequest
 // rules can have.
 // Note: Limited to 100 in order to be consistent with Tracker Blocking.
-const CEILING_PRIORITY = 20100
+export const CEILING_PRIORITY = 20100
 
-const MAXIMUM_RULES_PER_TRACKER_ENTRY = (CEILING_PRIORITY - BASELINE_PRIORITY) /
-                                            PRIORITY_INCREMENT
+export const MAXIMUM_RULES_PER_TRACKER_ENTRY =
+    (CEILING_PRIORITY - BASELINE_PRIORITY) / PRIORITY_INCREMENT
 
 /**
  * Generator to produce the declarativeNetRequest rules and corresponding match
  * details for the given trackerAllowlist configuration.
  * @param {object} extensionConfiguration
  *   The extension configuration.
- * @return {Generator<[import('./trackerBlocking').DNRRule, object]>}
+ * @return {Generator<[import('./trackerBlocking.js').DNRRule, object]>}
  */
-function* generateTrackerAllowlistRules ({ features: { trackerAllowlist } }) {
+export function* generateTrackerAllowlistRules (
+    { features: { trackerAllowlist } }
+) {
     // No allowlisted trackers.
     if (!trackerAllowlist ||
         trackerAllowlist.state !== 'enabled' ||
@@ -124,10 +122,3 @@ function* generateTrackerAllowlistRules ({ features: { trackerAllowlist } }) {
         }
     }
 }
-
-exports.BASELINE_PRIORITY = BASELINE_PRIORITY
-exports.PRIORITY_INCREMENT = PRIORITY_INCREMENT
-exports.CEILING_PRIORITY = CEILING_PRIORITY
-exports.MAXIMUM_RULES_PER_TRACKER_ENTRY = MAXIMUM_RULES_PER_TRACKER_ENTRY
-
-exports.generateTrackerAllowlistRules = generateTrackerAllowlistRules

--- a/lib/trackerBlocking.js
+++ b/lib/trackerBlocking.js
@@ -1,33 +1,31 @@
-/** @module trackerBlocking */
-
-const { storeInLookup } = require('./utils')
+import { storeInLookup } from './utils.js'
 
 // Priority that the Tracker Blocking declarativeNetRequest rules start from.
-const BASELINE_PRIORITY = 10000
+export const BASELINE_PRIORITY = 10000
 
 // Highest possible priority Tracker Blocking declarativeNetRequest rules can
 // have. Necessary to ensure that the relative priority between the extension's
 // declarativeNetRequest rules can be assured.
-const CEILING_PRIORITY = 19999
+export const CEILING_PRIORITY = 19999
 
 // Each time a more specific tracker domain is found, the priority for
 // corresponding declarativeNetRequest rules are incremented to ensure that
 // longer matching tracker domains match first.
-const SUBDOMAIN_PRIORITY_INCREMENT = 100
+export const SUBDOMAIN_PRIORITY_INCREMENT = 100
 
 // Tracker entry's rules are matched in order, to achieve that the corresponding
 // declarativeNetRequest rules are given a descending priority.
-const TRACKER_RULE_PRIORITY_INCREMENT = 1
+export const TRACKER_RULE_PRIORITY_INCREMENT = 1
 
 // Limit the number of tracker entries there can be for a domain, to avoid the
 // ceiling priority from being exceeded.
-const MAXIMUM_SUBDOMAIN_PRIORITY =
+export const MAXIMUM_SUBDOMAIN_PRIORITY =
       CEILING_PRIORITY - (CEILING_PRIORITY % SUBDOMAIN_PRIORITY_INCREMENT)
 
 // Limit the additional priority a tracker entry's rules can have, to avoid the
 // subdomain priority increment from being exceeded by the tracker rule priority
 // increment.
-const MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT =
+export const MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT =
     SUBDOMAIN_PRIORITY_INCREMENT - TRACKER_RULE_PRIORITY_INCREMENT
 
 // The declarativeNetRequest API limits the number of regular expression rules
@@ -36,7 +34,7 @@ const MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT =
 // other aspects of the extension, set an arbitrary limit of 900 for
 // Tracker Blocking.
 // See https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#property-MAX_NUMBER_OF_REGEX_RULES
-const MAXIMUM_REGEX_RULES = 900
+export const MAXIMUM_REGEX_RULES = 900
 
 // Characters that indicate a tracker rule needs to be treated as a regular
 // expression (rather than a URL filter).
@@ -115,7 +113,7 @@ const resourceTypes = new Set([
  * @param {generateDNRRuleDetails} ruleDetails
  * @return {DNRRule}
  */
-function generateDNRRule ({
+export function generateDNRRule ({
     id, priority, actionType, urlFilter, regexFilter, resourceTypes,
     requestDomains, excludedRequestDomains, initiatorDomains,
     excludedInitiatorDomains, matchCase = false
@@ -395,7 +393,9 @@ function normalizeTrackerRule (trackerRule) {
     return trackerRule
 }
 
-function getTrackerEntryDomain (trackerEntries, domain, skipSubdomains = 0) {
+export function getTrackerEntryDomain (
+    trackerEntries, domain, skipSubdomains = 0
+) {
     // Strip leading '.' in cname entries, nothing otherwise.
     let i = domain[0] === '.' ? 0 : -1
 
@@ -698,7 +698,7 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
  *   IDs are incremented sequentially from the starting point.
  * @return {Promise<generateTrackerBlockingRulesetResult>}
  */
-async function generateTrackerBlockingRuleset (
+export async function generateTrackerBlockingRuleset (
     tds, isRegexSupported, startingRuleId = 1
 ) {
     if (typeof tds !== 'object' ||
@@ -788,17 +788,3 @@ async function generateTrackerBlockingRuleset (
 
     return finalizeDNRRulesAndLookup(startingRuleId, dnrRules)
 }
-
-exports.BASELINE_PRIORITY = BASELINE_PRIORITY
-exports.CEILING_PRIORITY = CEILING_PRIORITY
-exports.SUBDOMAIN_PRIORITY_INCREMENT = SUBDOMAIN_PRIORITY_INCREMENT
-exports.TRACKER_RULE_PRIORITY_INCREMENT = TRACKER_RULE_PRIORITY_INCREMENT
-exports.MAXIMUM_SUBDOMAIN_PRIORITY = MAXIMUM_SUBDOMAIN_PRIORITY
-exports.MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT =
-    MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT
-exports.MAXIMUM_REGEX_RULES = MAXIMUM_REGEX_RULES
-
-exports.getTrackerEntryDomain = getTrackerEntryDomain
-exports.generateDNRRule = generateDNRRule
-
-exports.generateTrackerBlockingRuleset = generateTrackerBlockingRuleset

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,4 @@
-/** @module utils */
-
-function storeInLookup (lookup, key, values) {
+export function storeInLookup (lookup, key, values) {
     let storedValues = lookup.get(key)
     if (!storedValues) {
         storedValues = []
@@ -10,5 +8,3 @@ function storeInLookup (lookup, key, values) {
         storedValues.push(value)
     }
 }
-
-exports.storeInLookup = storeInLookup

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Scripts to generate declarativeNetRequest rulesets for the DuckDuckGo Privacy Essentials extension",
     "license": "Apache-2.0",
     "repository": "duckduckgo/ddg2dnr",
+    "type": "module",
     "devDependencies": {
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445",
         "@types/chrome": "0.0.195",

--- a/puppeteerInterface.js
+++ b/puppeteerInterface.js
@@ -1,16 +1,16 @@
-/** @module puppeteerInterface */
-
 // @ts-nocheck - ruleById property on self Object inside background
 //               ServiceWorker context for the extension is cumbersome to type
 //               hint with JSDoc comments.
 
-const path = require('path')
-const puppeteer = require('puppeteer')
+import * as path from 'path'
+import * as puppeteer from 'puppeteer'
+import { fileURLToPath } from 'url'
 
-class PuppeteerInterface {
+export class PuppeteerInterface {
     async setupBrowser () {
         const testExtensionPath = path.join(
-            __dirname, 'test', 'data', 'chrome-extension'
+            path.dirname(fileURLToPath(import.meta.url)),
+            'test', 'data', 'chrome-extension'
         )
 
         // Open the browser, installing the test extension.
@@ -177,5 +177,3 @@ class PuppeteerInterface {
         )
     }
 }
-
-exports.PuppeteerInterface = PuppeteerInterface

--- a/test/extensionConfiguration.js
+++ b/test/extensionConfiguration.js
@@ -1,8 +1,8 @@
-const assert = require('assert')
+import * as assert from 'assert'
 
-const {
+import {
     generateExtensionConfigurationRuleset
-} = require('../lib/extensionConfiguration')
+} from '../lib/extensionConfiguration.js'
 
 describe('generateExtensionConfigurationRuleset', () => {
     it('should reject invalid extension configuration', async () => {

--- a/test/referenceTests.js
+++ b/test/referenceTests.js
@@ -1,17 +1,15 @@
-const assert = require('assert')
-const fs = require('fs')
-const path = require('path')
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
 
-const {
-    generateSmarterEncryptionRuleset
-} = require('../lib/smarterEncryption')
-const {
-    generateTrackerBlockingRuleset
-} = require('../lib/trackerBlocking')
+import { generateSmarterEncryptionRuleset } from '../lib/smarterEncryption.js'
+import { generateTrackerBlockingRuleset } from '../lib/trackerBlocking.js'
 
 function referenceTestPath (...args) {
     return path.join(
-        __dirname, '..', 'node_modules', '@duckduckgo/privacy-reference-tests',
+        path.dirname(fileURLToPath(import.meta.url)), '..',
+        'node_modules', '@duckduckgo/privacy-reference-tests',
         ...args
     )
 }

--- a/test/rulePriorities.js
+++ b/test/rulePriorities.js
@@ -1,18 +1,16 @@
-const assert = require('assert')
+import * as assert from 'assert'
 
-const {
-    SMARTER_ENCRYPTION_PRIORITY
-} = require('../lib/smarterEncryption')
+import { SMARTER_ENCRYPTION_PRIORITY } from '../lib/smarterEncryption.js'
 
-const {
-    BASELINE_PRIORITY: TRACKER_BLOCKING_BASELINE_PRIORITY,
-    CEILING_PRIORITY: TRACKER_BLOCKING_CEILING_PRIORITY
-} = require('../lib/trackerBlocking')
+import {
+    BASELINE_PRIORITY as TRACKER_BLOCKING_BASELINE_PRIORITY,
+    CEILING_PRIORITY as TRACKER_BLOCKING_CEILING_PRIORITY
+} from '../lib/trackerBlocking.js'
 
-const {
-    BASELINE_PRIORITY: TRACKER_ALLOWLIST_BASELINE_PRIORITY,
-    CEILING_PRIORITY: TRACKER_ALLOWLIST_CEILING_PRIORITY
-} = require('../lib/trackerAllowlist')
+import {
+    BASELINE_PRIORITY as TRACKER_ALLOWLIST_BASELINE_PRIORITY,
+    CEILING_PRIORITY as TRACKER_ALLOWLIST_CEILING_PRIORITY
+} from '../lib/trackerAllowlist.js'
 
 describe('Rule Priorities', () => {
     it('correct relative rule priorities', () => {

--- a/test/smarterEncryption.js
+++ b/test/smarterEncryption.js
@@ -1,9 +1,9 @@
-const assert = require('assert')
+import * as assert from 'assert'
 
-const {
+import {
     SMARTER_ENCRYPTION_PRIORITY,
     generateSmarterEncryptionRuleset
-} = require('../lib/smarterEncryption')
+} from '../lib/smarterEncryption.js'
 
 describe('generateSmarterEncryptionRuleset', () => {
     it('should return an empty list of rules if there are no domains', () => {

--- a/test/trackerAllowlist.js
+++ b/test/trackerAllowlist.js
@@ -1,14 +1,14 @@
-const assert = require('assert')
+import * as assert from 'assert'
 
-const {
+import {
     BASELINE_PRIORITY,
     PRIORITY_INCREMENT,
     MAXIMUM_RULES_PER_TRACKER_ENTRY
-} = require('../lib/trackerAllowlist')
+} from '../lib/trackerAllowlist.js'
 
-const {
+import {
     generateExtensionConfigurationRuleset
-} = require('../lib/extensionConfiguration')
+} from '../lib/extensionConfiguration.js'
 
 async function isRegexSupportedTrue ({ regex, isCaseSensitive }) {
     return { isSupported: true }

--- a/test/trackerBlocking.js
+++ b/test/trackerBlocking.js
@@ -1,6 +1,6 @@
-const assert = require('assert')
+import * as assert from 'assert'
 
-const {
+import {
     BASELINE_PRIORITY,
     SUBDOMAIN_PRIORITY_INCREMENT,
     TRACKER_RULE_PRIORITY_INCREMENT,
@@ -8,7 +8,7 @@ const {
     MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT,
     MAXIMUM_REGEX_RULES,
     generateTrackerBlockingRuleset
-} = require('../lib/trackerBlocking')
+} from '../lib/trackerBlocking.js'
 
 const MAXIMUM_RULES_PER_DOMAIN = Math.floor(
     MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT /

--- a/test/utils/hooks.js
+++ b/test/utils/hooks.js
@@ -1,6 +1,6 @@
-const { PuppeteerInterface } = require('../../puppeteerInterface')
+import { PuppeteerInterface } from '../../puppeteerInterface.js'
 
-exports.mochaHooks = {
+export const mochaHooks = {
     async beforeAll () {
         this.timeout(20000)
         this.browser = new PuppeteerInterface()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2021",
+    "target": "es2022",
+    "module": "es2022",
     "moduleResolution": "node",
     "alwaysStrict": true,
     "allowJs": true,


### PR DESCRIPTION
We've been using the CommonJS module syntax so far, but ES modules are
the modern option. Let's update the codebase here to use ES modules.