### PR TITLE
Set up Dependabot insecure dependency alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot[1] is a service that can warn developers about outdated and
insecure dependencies. Let's enable that here.

1 - https://docs.github.com/en/code-security/dependabot