### PR TITLE
Add JSDoc comment for getTrackerEntryDomain

### DIFF
--- a/lib/trackerAllowlist.js
+++ b/lib/trackerAllowlist.js
@@ -44,6 +44,7 @@ function* generateTrackerAllowlistRules ({ features: { trackerAllowlist } }) {
     // situation.
     const excludedRequestDomainsByTrackerEntry = new Map()
     for (const trackerDomain of Object.keys(allowlistedTrackers)) {
+        /** @type {string|null} */
         let currentTrackerDomain = trackerDomain
         while (currentTrackerDomain) {
             currentTrackerDomain = getTrackerEntryDomain(

--- a/lib/trackerBlocking.js
+++ b/lib/trackerBlocking.js
@@ -1,5 +1,38 @@
 /** @module trackerBlocking */
 
+/**
+ * Unfortunately it's a little tricky to interact with TypeScript Enum types
+ * from JavaScript code, assigning the literal value (even if valid) results in
+ * a type coercion error. As a workaround, use the backtick syntax to get the
+ * possible enum values and then use those values to declare new types.
+ * Hopefully, interacting with Enums will get easier in the future and this can
+ * be removed.
+ * @typedef {`${chrome.declarativeNetRequest.DomainType}`} DomainType
+ * @typedef {`${chrome.declarativeNetRequest.RequestMethod}`} RequestMethod
+ * @typedef {`${chrome.declarativeNetRequest.ResourceType}`} ResourceType
+ * @typedef {`${chrome.declarativeNetRequest.RuleActionType}`} DNRRuleActionType
+ * @typedef {Omit<chrome.declarativeNetRequest.RuleAction,
+ *                'type' | 'redirect' | 'requestHeaders' | 'responseHeaders'> &
+ *           {type: DNRRuleActionType, redirect?: object,
+ *            requestHeaders?: object, responseHeaders?: object}} DNRRuleAction
+ * @typedef {Omit<chrome.declarativeNetRequest.RuleCondition,
+ *               'domainType' | 'excludedRequestMethods' |
+ *               'excludedResourceTypes' | 'requestMethods' |
+ *               'resourceTypes'> &
+ *           {domainType?: DomainType, excludedRequestMethods?: RequestMethod[],
+ *            excludedResourceTypes?: ResourceType[],
+ *            requestMethods?: RequestMethod[],
+ *            resourceTypes?: ResourceType[]}} DNRRuleCondition
+ * @typedef {Omit<chrome.declarativeNetRequest.Rule,
+ *                'id' | 'action' | 'condition'> &
+ *           {id?: number, action: DNRRuleAction,
+              condition: DNRRuleCondition}} DNRRule
+ */
+
+/**
+ *  @typedef {import("../node_modules/@duckduckgo/privacy-grade/src/classes/trackers.js").TrackerObj} TrackerObj
+ */
+
 const { storeInLookup } = require('./utils')
 
 // Priority that the Tracker Blocking declarativeNetRequest rules start from.
@@ -65,35 +98,6 @@ const resourceTypes = new Set([
     'object', 'xmlhttprequest', 'ping', 'csp_report', 'media', 'websocket',
     'webtransport', 'webbundle', 'other'
 ])
-
-/**
- * Unfortunately it's a little tricky to interact with TypeScript Enum types
- * from JavaScript code, assigning the literal value (even if valid) results in
- * a type coercion error. As a workaround, use the backtick syntax to get the
- * possible enum values and then use those values to declare new types.
- * Hopefully, interacting with Enums will get easier in the future and this can
- * be removed.
- * @typedef {`${chrome.declarativeNetRequest.DomainType}`} DomainType
- * @typedef {`${chrome.declarativeNetRequest.RequestMethod}`} RequestMethod
- * @typedef {`${chrome.declarativeNetRequest.ResourceType}`} ResourceType
- * @typedef {`${chrome.declarativeNetRequest.RuleActionType}`} DNRRuleActionType
- * @typedef {Omit<chrome.declarativeNetRequest.RuleAction,
- *                'type' | 'redirect' | 'requestHeaders' | 'responseHeaders'> &
- *           {type: DNRRuleActionType, redirect?: object,
- *            requestHeaders?: object, responseHeaders?: object}} DNRRuleAction
- * @typedef {Omit<chrome.declarativeNetRequest.RuleCondition,
- *               'domainType' | 'excludedRequestMethods' |
- *               'excludedResourceTypes' | 'requestMethods' |
- *               'resourceTypes'> &
- *           {domainType?: DomainType, excludedRequestMethods?: RequestMethod[],
- *            excludedResourceTypes?: ResourceType[],
- *            requestMethods?: RequestMethod[],
- *            resourceTypes?: ResourceType[]}} DNRRuleCondition
- * @typedef {Omit<chrome.declarativeNetRequest.Rule,
- *                'id' | 'action' | 'condition'> &
- *           {id?: number, action: DNRRuleAction,
-              condition: DNRRuleCondition}} DNRRule
- */
 
 /**
  * @typedef {object} generateDNRRuleDetails
@@ -395,6 +399,23 @@ function normalizeTrackerRule (trackerRule) {
     return trackerRule
 }
 
+/**
+ * Finds the closest matching tracker entry for the given domain. Returns the
+ * tracking domain if one is found, null otherwise.
+ * @param {Record<string, TrackerObj>} trackerEntries
+ *   The trackers section of the Tracker Blocking configuration.
+ * @param {string} domain
+ *   The domain to search for. Subdomains will be stripped away until a matching
+ *   tracker domain is found, or there are no more subdomains left.
+ *   Note: Can optionally contain the "." prefix that is sometimes given for
+ *         cname domain entries in the configuration.
+ * @param {number} [skipSubdomains = 0]
+ *   The number of subdomains to skip. Useful when checking if the given domain
+ *   has further less-specific tracking entries that would have matched.
+ * @return {string|null}
+ *   The closest-matching (skipped subdomains allowing) tracking domain, or null
+ *   if none are found.
+ */
 function getTrackerEntryDomain (trackerEntries, domain, skipSubdomains = 0) {
     // Strip leading '.' in cname entries, nothing otherwise.
     let i = domain[0] === '.' ? 0 : -1

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.1.4",
             "license": "Apache-2.0",
             "devDependencies": {
+                "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445",
                 "@types/chrome": "0.0.195",
                 "@types/mocha": "^9.1.1",
@@ -121,6 +122,15 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/@duckduckgo/privacy-grade": {
+            "version": "1.1.0",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-grade.git#0b7ce45599c8529d1d5a8ef2e7ebb90dc3e7a521",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tldts": "^5.7.84"
             }
         },
         "node_modules/@duckduckgo/privacy-reference-tests": {
@@ -3095,6 +3105,24 @@
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
+        "node_modules/tldts": {
+            "version": "5.7.90",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-5.7.90.tgz",
+            "integrity": "sha512-DQzMUfzHiRzVpCHdAw7idTHxZXmXHOJG+5ZcRoRtlb+/aojyXKxa1o3xmb+fFaWTMkmQrL4UZZqGqgS5yZO+/g==",
+            "dev": true,
+            "dependencies": {
+                "tldts-core": "^5.7.90"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "5.7.90",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.7.90.tgz",
+            "integrity": "sha512-WQL+4xFfb9ScPcsNbnScgY1FnoC31Xha55tx97C6VOlN5FEmlpWJxD6Bq9uZ59Yi3g3tw2hd0PQQ1HrLmZktJQ==",
+            "dev": true
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3480,6 +3508,14 @@
                         "has-flag": "^3.0.0"
                     }
                 }
+            }
+        },
+        "@duckduckgo/privacy-grade": {
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-grade.git#0b7ce45599c8529d1d5a8ef2e7ebb90dc3e7a521",
+            "dev": true,
+            "from": "@duckduckgo/privacy-grade@github:duckduckgo/privacy-grade#2.1.1",
+            "requires": {
+                "tldts": "^5.7.84"
             }
         },
         "@duckduckgo/privacy-reference-tests": {
@@ -5670,6 +5706,21 @@
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "tldts": {
+            "version": "5.7.90",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-5.7.90.tgz",
+            "integrity": "sha512-DQzMUfzHiRzVpCHdAw7idTHxZXmXHOJG+5ZcRoRtlb+/aojyXKxa1o3xmb+fFaWTMkmQrL4UZZqGqgS5yZO+/g==",
+            "dev": true,
+            "requires": {
+                "tldts-core": "^5.7.90"
+            }
+        },
+        "tldts-core": {
+            "version": "5.7.90",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.7.90.tgz",
+            "integrity": "sha512-WQL+4xFfb9ScPcsNbnScgY1FnoC31Xha55tx97C6VOlN5FEmlpWJxD6Bq9uZ59Yi3g3tw2hd0PQQ1HrLmZktJQ==",
             "dev": true
         },
         "to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "license": "Apache-2.0",
     "repository": "duckduckgo/ddg2dnr",
     "devDependencies": {
+        "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445",
         "@types/chrome": "0.0.195",
         "@types/mocha": "^9.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,11 +16,8 @@
   },
   "include": [
       "*.js",
-      "**/*.js"
-  ],
-  "exclude": [
-      "node_modules",
-      "puppeteerInterface.js"
+      "**/*.js",
+      "node_modules/@duckduckgo/privacy-grade/src/classes/trackers.js"
   ],
   "types": [
       "chrome"


### PR DESCRIPTION
Add JSDoc comment for getTrackerEntryDomain, since Jonathan asked for
that. Also, take care to import the proper type definitions for
tracker blocking rules from the privacy-grade repository rather than
just using the Object type for those. In the future we can make use of
those type definitions elsewhere too.