### PR TITLE
Add support for "surrogate script" redirection rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,25 @@ npm install
 Generate a Smarter Encryption ruleset:
 
 ```bash
-npm run smarter-encryption ../list-of-domains.txt ../smarter-encryption-ruleset.json
+npm run smarter-encryption ../list-of-domains-input.txt ../smarter-encryption-ruleset-output.json
 ```
 
-Generate a Tracker Blocking ruleset:
+Generate the TDS ruleset:
 
 ```bash
-npm run tracker-blocking ../tds.json ../tracker-blocking-ruleset.json [../tracker-domain-by-rule-id.txt]
+npm run tds ../tds-input.json ../mapping-input.json ../tds-ruleset-output.json \
+        [../match-details-by-rule-id-output.json]
 ```
+
+Note:
+ - This includes both Tracker blocking (see [tds.json][3]) and
+   "surrogate script" redirection (see [mapping.json][4]).
 
 Generate the extension configuration ruleset:
 
 ```bash
-npm run extension-configuration ../extension-config.json ../extension-configuration-ruleset.json \
-        [../match-details-by-rule-id.json]
+npm run extension-configuration ../extension-config-input.json ../extension-configuration-ruleset-output.json \
+        [../match-details-by-rule-id-output.json]
 ```
 
 Note:
@@ -57,3 +62,5 @@ npm test
 
 [1]: https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/
 [2]: https://github.com/duckduckgo/duckduckgo-privacy-extension/
+[3]: https://staticcdn.duckduckgo.com/trackerblocking/v3/tds.json
+[4]: https://github.com/duckduckgo/tracker-surrogates/blob/main/mapping.json

--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,7 @@ const process = require('process')
 const { PuppeteerInterface } = require('./puppeteerInterface')
 
 const { generateSmarterEncryptionRuleset } = require('./lib/smarterEncryption')
-const { generateTrackerBlockingRuleset } = require('./lib/trackerBlocking')
+const { generateTdsRuleset } = require('./lib/tds')
 const { generateExtensionConfigurationRuleset } =
       require('./lib/extensionConfiguration')
 
@@ -35,24 +35,36 @@ async function main () {
             )
         }
         break
-    case 'tracker-blocking':
-        if (args.length < 2 || args.length > 3) {
+    case 'tds':
+        if (args.length < 3 || args.length > 4) {
             console.error(
-                'Usage: npm run tracker-blocking',
-                './tds-input.json ./ruleset-output.json',
-                '[./domain-by-rule-id-output.txt]'
+                'Usage: npm run tds',
+                './tds-input.json ./surrogate-input.json ',
+                './surrogates-ruleset-output.json ',
+                '[./match-details-by-rule-id-output.json]'
             )
         } else {
-            const [tdsFilePath, rulesetFilePath, mappingFilePath] = args
+            const [
+                tdsFilePath,
+                surrogatesFilePath,
+                rulesetFilePath,
+                mappingFilePath
+            ] = args
 
             const browser = new PuppeteerInterface()
             const isRegexSupported = browser.isRegexSupported.bind(browser)
 
-            const { ruleset, trackerDomainByRuleId } =
-                  await generateTrackerBlockingRuleset(
+            const { ruleset, matchDetailsByRuleId } =
+                  await generateTdsRuleset(
                       JSON.parse(
                           fs.readFileSync(tdsFilePath, { encoding: 'utf8' })
                       ),
+                      JSON.parse(
+                          fs.readFileSync(
+                              surrogatesFilePath, { encoding: 'utf8' }
+                          )
+                      ),
+                      '/web_accessible_resources/',
                       isRegexSupported
                   )
 
@@ -66,7 +78,7 @@ async function main () {
             if (mappingFilePath) {
                 fs.writeFileSync(
                     mappingFilePath,
-                    trackerDomainByRuleId.join('\n')
+                    JSON.stringify(matchDetailsByRuleId, null, '\t')
                 )
             }
         }
@@ -76,7 +88,7 @@ async function main () {
             console.error(
                 'Usage: npm run extension-configuration',
                 './extension-config-input.json ./ruleset-output.json ',
-                '[./domain-and-reason-by-rule-id-output.json]'
+                '[./match-details-by-rule-id-output.json]'
             )
         } else {
             const [

--- a/lib/extensionConfiguration.js
+++ b/lib/extensionConfiguration.js
@@ -4,7 +4,7 @@ const { generateTrackerAllowlistRules } = require('./trackerAllowlist')
 
 /**
  * @typedef {object} generateExtensionConfigurationRulesetResult
- * @property {object[]} ruleset
+ * @property {import('./utils.js').DNRRule[]} ruleset
  *   The generated declarativeNetRequest ruleset.
  * @property {object} matchDetailsByRuleId
  *   Rule ID -> match details.

--- a/lib/surrogates.js
+++ b/lib/surrogates.js
@@ -1,0 +1,75 @@
+/** @module surrogates */
+
+const {
+    generateDNRRule,
+    getEntityDomains,
+    getTrackerEntryDomain,
+    processPlaintextTrackerRule
+} = require('./utils')
+
+const PRIORITY = 100000
+
+/**
+ * Generates a declarativeNetRequest rule for the given surrogate script.
+ * @param {string} surrogateRule
+ *   The surrogate script matching rule (literally matched string).
+ * @param {string} surrogateScriptPath
+ *   The surrogate script path.
+ * @return {import('./utils').DNRRule}
+ */
+function generateSurrogateDNRRule (
+    tds, trackerDomain, surrogateRule, surrogateScriptPath
+) {
+    const {
+        urlFilter,
+        matchCase
+    } = processPlaintextTrackerRule(trackerDomain, surrogateRule)
+
+    const requestDomains = [trackerDomain]
+    const excludedInitiatorDomains = getEntityDomains(tds, trackerDomain)
+
+    return generateDNRRule({
+        priority: PRIORITY,
+        actionType: 'redirect',
+        redirect: { extensionPath: surrogateScriptPath },
+        urlFilter,
+        matchCase,
+        resourceTypes: ['script'],
+        requestDomains,
+        excludedInitiatorDomains
+    })
+}
+
+/**
+ * Generator to produce the declarativeNetRequest rules for "surrogate script"
+ * redirection.
+ * @param {object} tds
+ *   The Tracker Blocking configuration.
+ * @param {Record<string, Array<string, string>[]>} surrogatesConfig
+ *   The "surrogate script" mapping configuration. Tracking domain -> array of
+ *   rule + script path pairs.
+ * @param {string} surrogatePathPrefix
+ *   The path prefix for surrogate scripts, e.g. '/web_accessible_resources/'.
+ * @return {Generator<[import('./utils').DNRRule, object]>}
+ */
+function* generateSurrogatesRules (tds, surrogatesConfig, surrogatePathPrefix) {
+    for (const [domain, surrogates] of Object.entries(surrogatesConfig)) {
+        const trackerDomain =
+              getTrackerEntryDomain(tds.trackers, domain) || domain
+        for (const [surrogateRule, surrogateScriptPath] of surrogates) {
+            const rule = generateSurrogateDNRRule(
+                tds, trackerDomain, surrogateRule,
+                surrogatePathPrefix + surrogateScriptPath
+            )
+            const matchDetails = {
+                type: 'surrogateScript',
+                domain: trackerDomain,
+                rule: surrogateRule
+            }
+            yield [rule, matchDetails]
+        }
+    }
+}
+
+exports.generateSurrogatesRules = generateSurrogatesRules
+exports.PRIORITY = PRIORITY

--- a/lib/tds.js
+++ b/lib/tds.js
@@ -1,0 +1,64 @@
+/** @module tds */
+
+const { generateTrackerBlockingRuleset } = require('./trackerBlocking')
+const { generateSurrogatesRules } = require('./surrogates')
+
+/**
+ * @typedef {object} generateTdsRulesetResult
+ * @property {import('./utils.js').DNRRule[]} ruleset
+ *   The generated declarativeNetRequest ruleset.
+ * @property {object} matchDetailsByRuleId
+ *   Rule ID -> match details.
+ */
+
+/**
+ * Generated an extension configuration declarativeNetRequest ruleset.
+ * @param {object} tds
+ *   The Tracker Blocking configuration.
+ * @param {Record<string, Array<string, string>[]>} surrogatesConfig
+ *   The "surrogate script" mapping configuration. Tracking domain -> array of
+ *   rule + script path pairs.
+ * @param {string} surrogatePathPrefix
+ *   The path prefix for surrogate scripts, e.g. '/web_accessible_resources/'.
+ * @param {function} isRegexSupported
+ *   A function compatible with chrome.declarativeNetRequest.isRegexSupported.
+ *   See https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#method-isRegexSupported
+ * @param {number} [startingRuleId = 1]
+ *   Rule ID for the generated declarativeNetRequest rules to start from. Rule
+ *   IDs are incremented sequentially from the starting point.
+ * @return {Promise<generateTdsRulesetResult>}
+ */
+async function generateTdsRuleset (
+    tds, surrogatesConfig, surrogatePathPrefix, isRegexSupported,
+    startingRuleId = 1
+) {
+    if (typeof isRegexSupported !== 'function') {
+        throw new Error('Missing isRegexSupported function.')
+    }
+
+    // Tracker blocking.
+    const {
+        ruleset,
+        matchDetailsByRuleId
+    } = await generateTrackerBlockingRuleset(
+        tds, isRegexSupported, startingRuleId
+    )
+
+    let ruleId = startingRuleId + ruleset.length
+
+    // Surrogate scripts.
+    for (const result of generateSurrogatesRules(
+        tds, surrogatesConfig, surrogatePathPrefix
+    )) {
+        if (!result) continue
+
+        const [rule, matchDetails] = result
+        rule.id = ruleId++
+        ruleset.push(rule)
+        matchDetailsByRuleId[rule.id] = matchDetails
+    }
+
+    return { ruleset, matchDetailsByRuleId }
+}
+
+exports.generateTdsRuleset = generateTdsRuleset

--- a/lib/trackerAllowlist.js
+++ b/lib/trackerAllowlist.js
@@ -1,9 +1,11 @@
 /** @module trackerAllowlist */
 
-const { storeInLookup } = require('./utils')
 const {
-    getTrackerEntryDomain, generateDNRRule
-} = require('./trackerBlocking')
+    processPlaintextTrackerRule,
+    storeInLookup,
+    generateDNRRule,
+    getTrackerEntryDomain
+} = require('./utils')
 
 // Priority that the Tracker Blocking Allowlist declarativeNetRequest rules
 // start from.
@@ -24,7 +26,7 @@ const MAXIMUM_RULES_PER_TRACKER_ENTRY = (CEILING_PRIORITY - BASELINE_PRIORITY) /
  * details for the given trackerAllowlist configuration.
  * @param {object} extensionConfiguration
  *   The extension configuration.
- * @return {Generator<[import('./trackerBlocking').DNRRule, object]>}
+ * @return {Generator<[import('./utils').DNRRule, object]>}
  */
 function* generateTrackerAllowlistRules ({ features: { trackerAllowlist } }) {
     // No allowlisted trackers.
@@ -83,7 +85,7 @@ function* generateTrackerAllowlistRules ({ features: { trackerAllowlist } }) {
         let priority = BASELINE_PRIORITY
         for (let i = trackerEntryRules.length - 1; i >= 0; i--) {
             let {
-                rule: urlFilter,
+                rule: trackerRule,
                 domains: initiatorDomains,
                 reason: allowlistReason
             } = trackerEntryRules[i]
@@ -95,19 +97,16 @@ function* generateTrackerAllowlistRules ({ features: { trackerAllowlist } }) {
                 initiatorDomains = null
             }
 
-            // Tracker Blocking Allowlist entries do not support regular
-            // expression matching, so processTrackerRule cannot be used here.
-            if (urlFilter.startsWith(trackerDomain)) {
-                urlFilter = '||' + urlFilter
-            }
+            const {
+                urlFilter,
+                matchCase
+            } = processPlaintextTrackerRule(trackerDomain, trackerRule)
 
             const rule = generateDNRRule({
                 priority,
                 actionType: 'allow',
                 urlFilter,
-                // Note: In the future it would be nice to avoid
-                //       case-insensitive matching unless necessary.
-                matchCase: false,
+                matchCase,
                 requestDomains,
                 excludedRequestDomains,
                 initiatorDomains

--- a/lib/trackerBlocking.js
+++ b/lib/trackerBlocking.js
@@ -1,39 +1,12 @@
 /** @module trackerBlocking */
 
-/**
- * Unfortunately it's a little tricky to interact with TypeScript Enum types
- * from JavaScript code, assigning the literal value (even if valid) results in
- * a type coercion error. As a workaround, use the backtick syntax to get the
- * possible enum values and then use those values to declare new types.
- * Hopefully, interacting with Enums will get easier in the future and this can
- * be removed.
- * @typedef {`${chrome.declarativeNetRequest.DomainType}`} DomainType
- * @typedef {`${chrome.declarativeNetRequest.RequestMethod}`} RequestMethod
- * @typedef {`${chrome.declarativeNetRequest.ResourceType}`} ResourceType
- * @typedef {`${chrome.declarativeNetRequest.RuleActionType}`} DNRRuleActionType
- * @typedef {Omit<chrome.declarativeNetRequest.RuleAction,
- *                'type' | 'redirect' | 'requestHeaders' | 'responseHeaders'> &
- *           {type: DNRRuleActionType, redirect?: object,
- *            requestHeaders?: object, responseHeaders?: object}} DNRRuleAction
- * @typedef {Omit<chrome.declarativeNetRequest.RuleCondition,
- *               'domainType' | 'excludedRequestMethods' |
- *               'excludedResourceTypes' | 'requestMethods' |
- *               'resourceTypes'> &
- *           {domainType?: DomainType, excludedRequestMethods?: RequestMethod[],
- *            excludedResourceTypes?: ResourceType[],
- *            requestMethods?: RequestMethod[],
- *            resourceTypes?: ResourceType[]}} DNRRuleCondition
- * @typedef {Omit<chrome.declarativeNetRequest.Rule,
- *                'id' | 'action' | 'condition'> &
- *           {id?: number, action: DNRRuleAction,
-              condition: DNRRuleCondition}} DNRRule
- */
-
-/**
- *  @typedef {import("../node_modules/@duckduckgo/privacy-grade/src/classes/trackers.js").TrackerObj} TrackerObj
- */
-
-const { storeInLookup } = require('./utils')
+const {
+    generateDNRRule,
+    getEntityDomains,
+    getTrackerEntryDomain,
+    storeInLookup,
+    processRegexTrackerRule
+} = require('./utils')
 
 // Priority that the Tracker Blocking declarativeNetRequest rules start from.
 const BASELINE_PRIORITY = 10000
@@ -71,23 +44,6 @@ const MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT =
 // See https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#property-MAX_NUMBER_OF_REGEX_RULES
 const MAXIMUM_REGEX_RULES = 900
 
-// Characters that indicate a tracker rule needs to be treated as a regular
-// expression (rather than a URL filter).
-// Note: This is not perfect, but good enough for now to avoid using regexFilter
-//       unless needed. In the future improvements could be made (e.g. by
-//       ignoring a closing ']' unless an opening '[' was already seen).
-const regularExpressionChars = new Set(
-    ['.', '*', '+', '?', '{', '}', '[', ']', '{', '}']
-)
-
-// Tracker entries that 1. match cnames and 2. have rules that are anchored to
-// the tracker domain, will not match correctly using a urlFilter. As a
-// workaround, it is sometimes possible to instead use a regexFilter (in
-// combination with the requestDomains condition) that matches any domain, while
-// still anchoring the rest of the rule to the domain correctly.
-const cnameDomainAnchor = '[a-z]+://[^/?]*'
-const cnameDomainAnchorCompatibleRuleSuffix = /^(:[0-9]+)?[/?]/
-
 // During ruleset generation, the trackerDomain is stored with each
 // declarativeNetRequest rule to aid the creation of the trackerDomainByRuleId
 // lookup.
@@ -98,261 +54,6 @@ const resourceTypes = new Set([
     'object', 'xmlhttprequest', 'ping', 'csp_report', 'media', 'websocket',
     'webtransport', 'webbundle', 'other'
 ])
-
-/**
- * @typedef {object} generateDNRRuleDetails
- * @property {number} [id]
- * @property {number} priority
- * @property {DNRRuleActionType} actionType
- * @property {string} [urlFilter]
- * @property {string} [regexFilter]
- * @property {ResourceType[]} [resourceTypes]
- * @property {string[]} requestDomains
- * @property {string[]} [excludedRequestDomains]
- * @property {string[]} [initiatorDomains]
- * @property {string[]} [excludedInitiatorDomains]
- * @property {boolean} [matchCase]
- */
-
-/**
- * Generates a declarativeNetRequest rule with the given details.
- * @param {generateDNRRuleDetails} ruleDetails
- * @return {DNRRule}
- */
-function generateDNRRule ({
-    id, priority, actionType, urlFilter, regexFilter, resourceTypes,
-    requestDomains, excludedRequestDomains, initiatorDomains,
-    excludedInitiatorDomains, matchCase = false
-}) {
-    /** @type {DNRRule} */
-    const dnrRule = {
-        priority,
-        action: {
-            type: actionType
-        },
-        condition: {
-            requestDomains
-        }
-    }
-
-    if (typeof id === 'number') {
-        dnrRule.id = id
-    }
-
-    if (urlFilter) {
-        dnrRule.condition.urlFilter = urlFilter
-
-        // If the URL filter is anchored to a domain anyway, then additional
-        // (included) request domain conditions don't serve a purpose.
-        // Note: This is only a safe assumption since (so far) requestDomains
-        //       never contain a subdomain of the domain in the URL filter. That
-        //       is since:
-        //         1. the domain in the URL filter is always the tracker entry's
-        //            domain
-        //         2. cname entries never map to a subdomain of the same tracker
-        if (urlFilter[0] === '|' && urlFilter[1] === '|') {
-            delete dnrRule.condition.requestDomains
-        }
-
-        if (!matchCase) {
-            dnrRule.condition.isUrlFilterCaseSensitive = false
-        }
-    } else if (regexFilter) {
-        dnrRule.condition.regexFilter = regexFilter
-
-        if (!matchCase) {
-            dnrRule.condition.isUrlFilterCaseSensitive = false
-        }
-    }
-
-    if (resourceTypes && resourceTypes.length > 0) {
-        dnrRule.condition.resourceTypes = resourceTypes
-    }
-
-    if (initiatorDomains && initiatorDomains.length > 0) {
-        dnrRule.condition.initiatorDomains = initiatorDomains
-    }
-
-    if (excludedRequestDomains && excludedRequestDomains.length > 0) {
-        dnrRule.condition.excludedRequestDomains = excludedRequestDomains
-    }
-
-    // Note: It's not necessary to exclude initiator domains for allowing rules
-    //       since first-party requests will be allowed anyway.
-    if (excludedInitiatorDomains &&
-        excludedInitiatorDomains.length > 0 &&
-        actionType !== 'allow') {
-        if (excludedInitiatorDomains.length === 1 &&
-            requestDomains.length === 1) {
-            // Assume that if only one initiator domain is excluded (and there
-            // is only one request domain), that the excluded initiator domain
-            // is the same as the request domain.
-            dnrRule.condition.domainType = 'thirdParty'
-        } else {
-            dnrRule.condition.excludedInitiatorDomains =
-                excludedInitiatorDomains
-        }
-    }
-
-    return dnrRule
-}
-
-function alphaChar (charCode) {
-    return ((charCode >= 97 && charCode <= 122) ||
-            (charCode >= 65 && charCode <= 90))
-}
-
-function parseTrackerRule (domain, trackerRule) {
-    let requiresRegexFilter = false
-    let urlFilter = ''
-    let afterDomainRuleIndex = -1
-    let lastAlphaIndex = -1
-
-    let escaped = false
-    let previousCharWasPeriod = false
-
-    for (let i = 0; i < trackerRule.length; i++) {
-        const char = trackerRule[i]
-        const charCode = char.charCodeAt(0)
-
-        if (urlFilter.length === domain.length && afterDomainRuleIndex === -1) {
-            // Store the index in the trackerRule that corresponds to the first
-            // character after the domain part. That is assuming the rule is
-            // prefixed with the domain part... that is verified later.
-            afterDomainRuleIndex = i
-        }
-
-        if (escaped) {
-            // Matching (only) a '*' literal in a urlFilter does not seem to be
-            // possible. (Tested as of Chromium M101.)
-            if (char === '*') {
-                requiresRegexFilter = true
-                continue
-            }
-
-            if (alphaChar(charCode)) {
-                lastAlphaIndex = i
-            }
-
-            escaped = false
-            urlFilter += char
-            continue
-        }
-
-        if (char === '\\') {
-            escaped = true
-            continue
-        }
-
-        if (char === '.') {
-            previousCharWasPeriod = true
-            continue
-        }
-
-        if (char === '*' && previousCharWasPeriod) {
-            urlFilter += '*'
-            previousCharWasPeriod = false
-            continue
-        }
-
-        if (regularExpressionChars.has(char) || previousCharWasPeriod) {
-            requiresRegexFilter = true
-            continue
-        }
-
-        if (alphaChar(charCode)) {
-            lastAlphaIndex = i
-        }
-
-        urlFilter += char
-    }
-
-    if (previousCharWasPeriod) {
-        requiresRegexFilter = true
-    }
-
-    return {
-        requiresRegexFilter, urlFilter, afterDomainRuleIndex, lastAlphaIndex
-    }
-}
-
-function processTrackerRule (domain, trackerRule, matchCnames) {
-    // If the tracker rule is empty, then neither urlFilter nor regexFilter are
-    // necessary.
-    if (!trackerRule) {
-        return { }
-    }
-
-    let {
-        requiresRegexFilter, urlFilter, afterDomainRuleIndex, lastAlphaIndex
-    } = parseTrackerRule(domain, trackerRule)
-
-    let regexFilter = trackerRule
-    let matchCase = false
-    let usedRegexForWorkaround = false
-
-    if (urlFilter.startsWith(domain)) {
-        // If the the urlFilter is the same length as the domain, then the
-        // strings are equal (since the urlFilter starts with the domain).
-        // Neither urlFilter nor regexFilter are necessary.
-        if (urlFilter.length === domain.length) {
-            return { }
-        }
-
-        // Ignore the domain when considering if the rule needs to be matched
-        // case sensitively.
-        matchCase = lastAlphaIndex < afterDomainRuleIndex
-
-        if (urlFilter[domain.length] === '*') {
-            // If the urlFilter is longer than the domain, but the next
-            // character after the domain is a wildcard, the domain part +
-            // wildcard can be safely removed. That is since the domain part of
-            // a urlFilter only serves to anchor the filter against the start of
-            // the URL's path (thanks to requestDomains conditions).
-            // Note: Remove an extra character from the regexFilter, since the
-            //       wild-card for a regular expression is '.*' rather than just
-            //       '*'.
-            regexFilter = regexFilter.substr(afterDomainRuleIndex + 2)
-            urlFilter = urlFilter.substr(domain.length + 1)
-        } else {
-            // If the pattern needs to be anchored to the domain, and cname
-            // matching is required, then a regexFilter is necessary to anchor
-            // the rest of the filter to the request domain.
-            // Note: This workaround only works if there is a '/' or '?'
-            //       character directly after the domain (or port) part of the
-            //       rule.
-            if (matchCnames &&
-                afterDomainRuleIndex > -1 &&
-                cnameDomainAnchorCompatibleRuleSuffix
-                    .test(urlFilter.substr(domain.length))) {
-                usedRegexForWorkaround = true
-                regexFilter = cnameDomainAnchor +
-                                  trackerRule.substr(afterDomainRuleIndex)
-            }
-
-            // Prepend the '||' urlFilter domain anchor to improve matching
-            // performance.
-            urlFilter = '||' + urlFilter
-        }
-    } else {
-        // If there isn't a (known) domain part, then case sensitive matching can
-        // only happen if there were no alpha characters.
-        matchCase = lastAlphaIndex === -1
-    }
-
-    if (requiresRegexFilter) {
-        return { regexFilter, matchCase }
-    }
-
-    // The regular expression will sometimes be too complex (long) for a
-    // declarativeNetRequest rule. Provide the urlFilter as a fallback, but note
-    // that cnames will not be matched correctly by the urlFilter.
-    if (usedRegexForWorkaround) {
-        return { regexFilter, matchCase, urlFilterFallback: urlFilter }
-    }
-
-    return { urlFilter, matchCase }
-}
 
 function normalizeTypesCondition (types) {
     if (!types || types.length === 0) {
@@ -397,45 +98,6 @@ function normalizeTrackerRule (trackerRule) {
     }
 
     return trackerRule
-}
-
-/**
- * Finds the closest matching tracker entry for the given domain. Returns the
- * tracking domain if one is found, null otherwise.
- * @param {Record<string, TrackerObj>} trackerEntries
- *   The trackers section of the Tracker Blocking configuration.
- * @param {string} domain
- *   The domain to search for. Subdomains will be stripped away until a matching
- *   tracker domain is found, or there are no more subdomains left.
- *   Note: Can optionally contain the "." prefix that is sometimes given for
- *         cname domain entries in the configuration.
- * @param {number} [skipSubdomains = 0]
- *   The number of subdomains to skip. Useful when checking if the given domain
- *   has further less-specific tracking entries that would have matched.
- * @return {string|null}
- *   The closest-matching (skipped subdomains allowing) tracking domain, or null
- *   if none are found.
- */
-function getTrackerEntryDomain (trackerEntries, domain, skipSubdomains = 0) {
-    // Strip leading '.' in cname entries, nothing otherwise.
-    let i = domain[0] === '.' ? 0 : -1
-
-    do {
-        domain = domain.substr(i + 1)
-        i = domain.indexOf('.')
-
-        if (skipSubdomains > 0) {
-            skipSubdomains -= 1
-            continue
-        }
-
-        const trackerEntry = trackerEntries[domain]
-        if (trackerEntry) {
-            return domain
-        }
-    } while (i > -1)
-
-    return null
 }
 
 function calculateTrackerEntryPriorities (tds) {
@@ -572,7 +234,7 @@ async function generateDNRRulesForTrackerEntry (
             urlFilter,
             regexFilter,
             matchCase
-        } = processTrackerRule(trackerDomain, trackerRule, matchCnames)
+        } = processRegexTrackerRule(trackerDomain, trackerRule, matchCnames)
 
         // If the required regular expression is too complex, then go with the
         // fallback urlFilter (if any). If there is no fallback, skip this rule.
@@ -688,22 +350,24 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
         }
     }
 
-    // Create the ruleId -> trackerDomain lookup.
-    const trackerDomainByRuleId = new Array(startingRuleId)
+    // Create the ruleId -> matchDetails lookup.
+    const matchDetailsByRuleId = {}
     for (let i = startingRuleId; i < startingRuleId + ruleset.length; i++) {
-        trackerDomainByRuleId.push(trackerDomainsByRuleId.get(i).join(','))
+        matchDetailsByRuleId[i] = {
+            type: 'trackerBlocking',
+            possibleTrackerDomains: trackerDomainsByRuleId.get(i)
+        }
     }
 
-    return { ruleset, trackerDomainByRuleId }
+    return { ruleset, matchDetailsByRuleId }
 }
 
 /**
  * @typedef {object} generateTrackerBlockingRulesetResult
- * @property {DNRRule[]} ruleset
+ * @property {import('./utils.js').DNRRule[]} ruleset
  *   The generated Tracker Blocking declarativeNetRequest ruleset.
- * @property {(null|string)[]} trackerDomainByRuleId
- *   Rule ID -> tracker domain mapping. Useful for translating a rule match to
- *   a tracker entry.
+ * @property {object} matchDetailsByRuleId
+ *   Rule ID -> match details.
  */
 
 /**
@@ -785,8 +449,7 @@ async function generateTrackerBlockingRuleset (
     const dnrRules = []
     for (const [trackerDomain, trackerEntry] of Object.entries(tds.trackers)) {
         const requestDomains = requestDomainsByTrackerDomain.get(trackerDomain)
-        const excludedInitiatorDomains =
-              tds.entities[trackerEntry.owner.name].domains
+        const excludedInitiatorDomains = getEntityDomains(tds, trackerDomain)
         const priority = priorityByTrackerDomain.get(trackerDomain)
         for (const rule of await generateDNRRulesForTrackerEntry(
             trackerDomain, trackerEntry, requestDomains,
@@ -818,8 +481,5 @@ exports.MAXIMUM_SUBDOMAIN_PRIORITY = MAXIMUM_SUBDOMAIN_PRIORITY
 exports.MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT =
     MAXIMUM_TRACKER_RULE_PRIORITY_INCREMENT
 exports.MAXIMUM_REGEX_RULES = MAXIMUM_REGEX_RULES
-
-exports.getTrackerEntryDomain = getTrackerEntryDomain
-exports.generateDNRRule = generateDNRRule
 
 exports.generateTrackerBlockingRuleset = generateTrackerBlockingRuleset

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,55 @@
 /** @module utils */
 
+/**
+ *  @typedef {import('../node_modules/@duckduckgo/privacy-grade/src/classes/trackers.js').TrackerObj} TrackerObj
+ */
+
+/**
+ * Unfortunately it's a little tricky to interact with TypeScript Enum types
+ * from JavaScript code, assigning the literal value (even if valid) results in
+ * a type coercion error. As a workaround, use the backtick syntax to get the
+ * possible enum values and then use those values to declare new types.
+ * Hopefully, interacting with Enums will get easier in the future and this can
+ * be removed.
+ * @typedef {`${chrome.declarativeNetRequest.DomainType}`} DomainType
+ * @typedef {`${chrome.declarativeNetRequest.RequestMethod}`} RequestMethod
+ * @typedef {`${chrome.declarativeNetRequest.ResourceType}`} ResourceType
+ * @typedef {`${chrome.declarativeNetRequest.RuleActionType}`} DNRRuleActionType
+ * @typedef {Omit<chrome.declarativeNetRequest.RuleAction,
+ *                'type' | 'redirect' | 'requestHeaders' | 'responseHeaders'> &
+ *           {type: DNRRuleActionType, redirect?: object,
+ *            requestHeaders?: object, responseHeaders?: object}} DNRRuleAction
+ * @typedef {Omit<chrome.declarativeNetRequest.RuleCondition,
+ *               'domainType' | 'excludedRequestMethods' |
+ *               'excludedResourceTypes' | 'requestMethods' |
+ *               'resourceTypes'> &
+ *           {domainType?: DomainType, excludedRequestMethods?: RequestMethod[],
+ *            excludedResourceTypes?: ResourceType[],
+ *            requestMethods?: RequestMethod[],
+ *            resourceTypes?: ResourceType[]}} DNRRuleCondition
+ * @typedef {Omit<chrome.declarativeNetRequest.Rule,
+ *                'id' | 'action' | 'condition'> &
+ *           {id?: number, action: DNRRuleAction,
+ *            condition: DNRRuleCondition}} DNRRule
+ */
+
+// Tracker entries that 1. match cnames and 2. have rules that are anchored to
+// the tracker domain, will not match correctly using a urlFilter. As a
+// workaround, it is sometimes possible to instead use a regexFilter (in
+// combination with the requestDomains condition) that matches any domain, while
+// still anchoring the rest of the rule to the domain correctly.
+const cnameDomainAnchor = '[a-z]+://[^/?]*'
+const cnameDomainAnchorCompatibleRuleSuffix = /^(:[0-9]+)?[/?]/
+
+// Characters that indicate a tracker rule needs to be treated as a regular
+// expression (rather than a URL filter).
+// Note: This is not perfect, but good enough for now to avoid using regexFilter
+//       unless needed. In the future improvements could be made (e.g. by
+//       ignoring a closing ']' unless an opening '[' was already seen).
+const regularExpressionChars = new Set(
+    ['.', '*', '+', '?', '{', '}', '[', ']', '{', '}']
+)
+
 function storeInLookup (lookup, key, values) {
     let storedValues = lookup.get(key)
     if (!storedValues) {
@@ -11,4 +61,383 @@ function storeInLookup (lookup, key, values) {
     }
 }
 
+/**
+ * @typedef {object} generateDNRRuleDetails
+ * @property {number} [id]
+ * @property {number} priority
+ * @property {DNRRuleActionType} actionType
+ * @property {object} [redirect]
+ * @property {string} [urlFilter]
+ * @property {string} [regexFilter]
+ * @property {ResourceType[]} [resourceTypes]
+ * @property {string[]} requestDomains
+ * @property {string[]} [excludedRequestDomains]
+ * @property {string[]} [initiatorDomains]
+ * @property {string[]} [excludedInitiatorDomains]
+ * @property {boolean} [matchCase]
+ */
+
+/**
+ * Generates a declarativeNetRequest rule with the given details.
+ * @param {generateDNRRuleDetails} ruleDetails
+ * @return {DNRRule}
+ */
+function generateDNRRule ({
+    id, priority, actionType, redirect, urlFilter, regexFilter, resourceTypes,
+    requestDomains, excludedRequestDomains, initiatorDomains,
+    excludedInitiatorDomains, matchCase = false
+}) {
+    /** @type {DNRRule} */
+    const dnrRule = {
+        priority,
+        action: {
+            type: actionType
+        },
+        condition: {
+            requestDomains
+        }
+    }
+
+    if (typeof id === 'number') {
+        dnrRule.id = id
+    }
+
+    if (actionType === 'redirect' && redirect) {
+        dnrRule.action.redirect = redirect
+    }
+
+    if (urlFilter) {
+        dnrRule.condition.urlFilter = urlFilter
+
+        // If the URL filter is anchored to a domain anyway, then additional
+        // (included) request domain conditions don't serve a purpose.
+        // Note: This is only a safe assumption since (so far) requestDomains
+        //       never contain a subdomain of the domain in the URL filter. That
+        //       is since:
+        //         1. the domain in the URL filter is always the tracker entry's
+        //            domain
+        //         2. cname entries never map to a subdomain of the same tracker
+        if (urlFilter[0] === '|' && urlFilter[1] === '|') {
+            delete dnrRule.condition.requestDomains
+        }
+
+        if (!matchCase) {
+            dnrRule.condition.isUrlFilterCaseSensitive = false
+        }
+    } else if (regexFilter) {
+        dnrRule.condition.regexFilter = regexFilter
+
+        if (!matchCase) {
+            dnrRule.condition.isUrlFilterCaseSensitive = false
+        }
+    }
+
+    if (resourceTypes && resourceTypes.length > 0) {
+        dnrRule.condition.resourceTypes = resourceTypes
+    }
+
+    if (initiatorDomains && initiatorDomains.length > 0) {
+        dnrRule.condition.initiatorDomains = initiatorDomains
+    }
+
+    if (excludedRequestDomains && excludedRequestDomains.length > 0) {
+        dnrRule.condition.excludedRequestDomains = excludedRequestDomains
+    }
+
+    // Note: It's not necessary to exclude initiator domains for allowing rules
+    //       since first-party requests will be allowed anyway.
+    if (excludedInitiatorDomains &&
+        excludedInitiatorDomains.length > 0 &&
+        actionType !== 'allow') {
+        if (excludedInitiatorDomains.length === 1 &&
+            requestDomains.length === 1) {
+            // Assume that if only one initiator domain is excluded (and there
+            // is only one request domain), that the excluded initiator domain
+            // is the same as the request domain.
+            dnrRule.condition.domainType = 'thirdParty'
+        } else {
+            dnrRule.condition.excludedInitiatorDomains =
+                excludedInitiatorDomains
+        }
+    }
+
+    return dnrRule
+}
+
+function alphaChar (charCode) {
+    return ((charCode >= 97 && charCode <= 122) ||
+            (charCode >= 65 && charCode <= 90))
+}
+
+function parseRegexTrackerRule (domain, trackerRule) {
+    let requiresRegexFilter = false
+    let urlFilter = ''
+    let afterDomainRuleIndex = -1
+    let lastAlphaIndex = -1
+
+    let escaped = false
+    let previousCharWasPeriod = false
+
+    for (let i = 0; i < trackerRule.length; i++) {
+        const char = trackerRule[i]
+        const charCode = char.charCodeAt(0)
+
+        if (domain && urlFilter.length === domain.length &&
+            afterDomainRuleIndex === -1) {
+            // Store the index in the trackerRule that corresponds to the first
+            // character after the domain part. That is assuming the rule is
+            // prefixed with the domain part... that is verified later.
+            afterDomainRuleIndex = i
+        }
+
+        if (escaped) {
+            // Matching (only) a '*' literal in a urlFilter does not seem to be
+            // possible. (Tested as of Chromium M101.)
+            if (char === '*') {
+                requiresRegexFilter = true
+                continue
+            }
+
+            if (alphaChar(charCode)) {
+                lastAlphaIndex = i
+            }
+
+            escaped = false
+            urlFilter += char
+            continue
+        }
+
+        if (char === '\\') {
+            escaped = true
+            continue
+        }
+
+        if (char === '.') {
+            previousCharWasPeriod = true
+            continue
+        }
+
+        if (char === '*' && previousCharWasPeriod) {
+            urlFilter += '*'
+            previousCharWasPeriod = false
+            continue
+        }
+
+        if (regularExpressionChars.has(char) || previousCharWasPeriod) {
+            requiresRegexFilter = true
+            continue
+        }
+
+        if (alphaChar(charCode)) {
+            lastAlphaIndex = i
+        }
+
+        urlFilter += char
+    }
+
+    if (previousCharWasPeriod) {
+        requiresRegexFilter = true
+    }
+
+    return {
+        requiresRegexFilter, urlFilter, afterDomainRuleIndex, lastAlphaIndex
+    }
+}
+
+/**
+ * @typedef processRegexTrackerRuleResult
+ * @property {string} [urlFilter]
+ *   declarativeNetRequest urlFilter condition necessary to match this rule.
+ * @property {string} [regexFilter]
+ *   declarativeNetRequest regexFilter condition necessary to match this rule.
+ * @property {string} [fallbackUrlFilter]
+ *   A suboptimal urlFilter condition that can be used as a fallback if the
+ *   provided regexFilter is not supported by the declarativeNetRequest API.
+ * @property {boolean} [matchCase]
+ *   False if case insensitive matching is required for this rule.
+ */
+
+/**
+ * Figure out the declarativeNetRequest urlFilter or regexFilter (if any)
+ * necessary for matching the given regular expression tracker rule.
+ * @param {string|null} domain
+ *   The tracker entry's domain, or null if unknown.
+ * @param {string} trackerRule
+ *   The tracker entry's rule (regular expression string).
+ * @param {boolean} matchCnames
+ *   If cname matching is necessary for this rule.
+ * @return {processRegexTrackerRuleResult}
+ */
+function processRegexTrackerRule (domain, trackerRule, matchCnames) {
+    // If the tracker rule is empty, then neither urlFilter nor regexFilter are
+    // necessary.
+    if (!trackerRule) {
+        return { }
+    }
+
+    let {
+        requiresRegexFilter, urlFilter, afterDomainRuleIndex, lastAlphaIndex
+    } = parseRegexTrackerRule(domain, trackerRule)
+
+    let regexFilter = trackerRule
+    let matchCase = false
+    let usedRegexForWorkaround = false
+
+    if (domain && urlFilter.startsWith(domain)) {
+        // If the the urlFilter is the same length as the domain, then the
+        // strings are equal (since the urlFilter starts with the domain).
+        // Neither urlFilter nor regexFilter are necessary.
+        if (urlFilter.length === domain.length) {
+            return { }
+        }
+
+        // Ignore the domain when considering if the rule needs to be matched
+        // case sensitively.
+        matchCase = lastAlphaIndex < afterDomainRuleIndex
+
+        if (urlFilter[domain.length] === '*') {
+            // If the urlFilter is longer than the domain, but the next
+            // character after the domain is a wildcard, the domain part +
+            // wildcard can be safely removed. That is since the domain part of
+            // a urlFilter only serves to anchor the filter against the start of
+            // the URL's path (thanks to requestDomains conditions).
+            // Note: Remove an extra character from the regexFilter, since the
+            //       wild-card for a regular expression is '.*' rather than just
+            //       '*'.
+            regexFilter = regexFilter.substr(afterDomainRuleIndex + 2)
+            urlFilter = urlFilter.substr(domain.length + 1)
+        } else {
+            // If the pattern needs to be anchored to the domain, and cname
+            // matching is required, then a regexFilter is necessary to anchor
+            // the rest of the filter to the request domain.
+            // Note: This workaround only works if there is a '/' or '?'
+            //       character directly after the domain (or port) part of the
+            //       rule.
+            if (matchCnames &&
+                afterDomainRuleIndex > -1 &&
+                cnameDomainAnchorCompatibleRuleSuffix
+                    .test(urlFilter.substr(domain.length))) {
+                usedRegexForWorkaround = true
+                regexFilter = cnameDomainAnchor +
+                                  trackerRule.substr(afterDomainRuleIndex)
+            }
+
+            // Prepend the '||' urlFilter domain anchor to improve matching
+            // performance.
+            urlFilter = '||' + urlFilter
+        }
+    } else {
+        // If there isn't a (known) domain part, then case sensitive matching
+        // can only happen if there were no alpha characters.
+        matchCase = lastAlphaIndex === -1
+    }
+
+    if (requiresRegexFilter) {
+        return { regexFilter, matchCase }
+    }
+
+    // The regular expression will sometimes be too complex (long) for a
+    // declarativeNetRequest rule. Provide the urlFilter as a fallback, but note
+    // that cnames will not be matched correctly by the urlFilter.
+    if (usedRegexForWorkaround) {
+        return { regexFilter, matchCase, fallbackUrlFilter: urlFilter }
+    }
+
+    return { urlFilter, matchCase }
+}
+
+/**
+ * @typedef processPlaintextTrackerRuleResult
+ * @property {string} urlFilter
+ *   declarativeNetRequest urlFilter condition necessary to match this rule.
+ * @property {boolean} matchCase
+ *   False if case insensitive matching is required for this rule.
+ */
+
+/**
+ * Figure out the declarativeNetRequest urlFilter necessary for matching the
+ * given plain-text tracker rule.
+ * @param {string|null} domain
+ *   The tracker entry's domain, or null if unknown.
+ * @param {string} trackerRule
+ *   The tracker entry's rule (literal string to match).
+ * @return {processPlaintextTrackerRuleResult}
+ */
+function processPlaintextTrackerRule (domain, trackerRule) {
+    let urlFilter = trackerRule
+
+    if (domain && urlFilter.startsWith(domain)) {
+        urlFilter = '||' + urlFilter
+    }
+
+    // Note: In the future it would be nice to avoid case-insensitive matching
+    //       unless necessary. The logic to do that could potentially be shared
+    //       with processRegexTrackerRule.
+    const matchCase = false
+
+    return { urlFilter, matchCase }
+}
+
+/**
+ * Finds the closest matching tracker entry for the given domain. Returns the
+ * tracking domain if one is found, null otherwise.
+ * @param {Record<string, import('./utils.js').TrackerObj>} trackerEntries
+ *   The trackers section of the Tracker Blocking configuration.
+ * @param {string} domain
+ *   The domain to search for. Subdomains will be stripped away until a matching
+ *   tracker domain is found, or there are no more subdomains left.
+ *   Note: Can optionally contain the "." prefix that is sometimes given for
+ *         cname domain entries in the configuration.
+ * @param {number} [skipSubdomains = 0]
+ *   The number of subdomains to skip. Useful when checking if the given domain
+ *   has further less-specific tracking entries that would have matched.
+ * @return {string|null}
+ *   The closest-matching (skipped subdomains allowing) tracking domain, or null
+ *   if none are found.
+ */
+function getTrackerEntryDomain (trackerEntries, domain, skipSubdomains = 0) {
+    // Strip leading '.' in cname entries, nothing otherwise.
+    let i = domain[0] === '.' ? 0 : -1
+
+    do {
+        domain = domain.substr(i + 1)
+        i = domain.indexOf('.')
+
+        if (skipSubdomains > 0) {
+            skipSubdomains -= 1
+            continue
+        }
+
+        const trackerEntry = trackerEntries[domain]
+        if (trackerEntry) {
+            return domain
+        }
+    } while (i > -1)
+
+    return null
+}
+
+/**
+ * Find the list of same-entity domains for the given tracking domain.
+ * @param {object} tds
+ *   The Tracker Blocking configuration.
+ * @param {string} trackerDomain
+ *   The tracker entry's domain.
+ * @return {string[]}
+ */
+function getEntityDomains (tds, trackerDomain) {
+    const entity = tds.domains[trackerDomain]
+
+    if (!entity) {
+        return [trackerDomain]
+    }
+
+    return tds.entities[entity]?.domains || [trackerDomain]
+}
+
 exports.storeInLookup = storeInLookup
+exports.generateDNRRule = generateDNRRule
+exports.processRegexTrackerRule = processRegexTrackerRule
+exports.processPlaintextTrackerRule = processPlaintextTrackerRule
+exports.getTrackerEntryDomain = getTrackerEntryDomain
+exports.getEntityDomains = getEntityDomains

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "lint": "npm run eslint && npm run tsc",
         "smarter-encryption": "node cli.js smarter-encryption",
         "test": "mocha",
-        "tracker-blocking": "node cli.js tracker-blocking"
+        "tds": "node cli.js tds"
     },
     "mocha": {
         "require": "test/utils/hooks.js"

--- a/test/referenceTests.js
+++ b/test/referenceTests.js
@@ -59,8 +59,11 @@ describe('Reference Tests', () => {
             testDescription, requestURL: initialUrl, requestType,
             siteURL: initiatorUrl, expectAction: expectedAction
         } of testCases(referenceTests)) {
-            // Note: Stop skipping these test cases once support for
-            //       Surrogates has been added.
+            // Note: Stop skipping these test cases once
+            //       privacy-reference-tests[1] provides the modern
+            //       mapping.json[2] surrogates file.
+            // 1 - https://github.com/duckduckgo/privacy-reference-tests/tree/main/tracker-radar-tests/TR-domain-matching
+            // 2 - https://github.com/duckduckgo/tracker-surrogates/blob/main/mapping.json
             if (testDescription.startsWith('surrogate-tests:')) {
                 continue
             }

--- a/test/rulePriorities.js
+++ b/test/rulePriorities.js
@@ -14,8 +14,14 @@ const {
     CEILING_PRIORITY: TRACKER_ALLOWLIST_CEILING_PRIORITY
 } = require('../lib/trackerAllowlist')
 
+const {
+    PRIORITY: SURROGATES_PRIORITY
+} = require('../lib/surrogates')
+
 describe('Rule Priorities', () => {
     it('correct relative rule priorities', () => {
+        // Blocking/allowing rules.
+
         // Tracker Blocking priorities.
         assert.ok(TRACKER_BLOCKING_BASELINE_PRIORITY > 0)
         assert.ok(TRACKER_BLOCKING_CEILING_PRIORITY >
@@ -25,14 +31,22 @@ describe('Rule Priorities', () => {
         assert.ok(TRACKER_ALLOWLIST_BASELINE_PRIORITY >
                   TRACKER_BLOCKING_CEILING_PRIORITY)
 
+        // Redirection rules.
+        // Notes:
+        //   - It's important that the redirection rules have a higher priority
+        //     than Tracker Blocking etc rules. After a request is redirect, the
+        //     request will still match against other block/allow rules. But
+        //     after an allow rules matches a request, the redirection rules
+        //     will no longer have the opportunity to match.
+        //   - Relative priority between redirection rules does not matter for
+        //     the same reason.
+
         // Smarter Encryption priority.
-        // Note: It's important that the Smarter Encryption rule priority is
-        //       higher than the priority for Tracker Blocking etc rules.
-        //       After a request is redirected to use HTTPS, the redirected
-        //       request will still match against other block/allow rules. But
-        //       after an allow rules matches a request, upgrade schema rules
-        //       will no longer have the opportunity to match.
         assert.ok(SMARTER_ENCRYPTION_PRIORITY >
+                  TRACKER_ALLOWLIST_CEILING_PRIORITY)
+
+        // Surrogate Scripts redirection priority.
+        assert.ok(SURROGATES_PRIORITY >
                   TRACKER_ALLOWLIST_CEILING_PRIORITY)
     })
 })

--- a/test/surrogates.js
+++ b/test/surrogates.js
@@ -1,0 +1,442 @@
+const assert = require('assert')
+
+const {
+    PRIORITY
+} = require('../lib/surrogates')
+
+const {
+    generateTdsRuleset
+} = require('../lib/tds')
+
+async function isRegexSupportedTrue ({ regex, isCaseSensitive }) {
+    return { isSupported: true }
+}
+
+const googleTrackerEntry = {
+    owner: {
+        name: 'Google LLC',
+        displayName: 'Google',
+        privacyPolicy: 'https://policies.google.com/privacy?hl=en&gl=us',
+        url: 'http://google.com'
+    },
+    prevalence: 0.691,
+    fingerprinting: 2,
+    cookies: 0.619,
+    categories: [],
+    default: 'allow',
+    rules: []
+}
+
+const tds = {
+    cnames: {},
+    domains: {
+        'google-analytics.com': googleTrackerEntry.owner.name,
+        'googletagmanager.com': googleTrackerEntry.owner.name,
+        'googletagservices.com': googleTrackerEntry.owner.name,
+        'googlesyndication.com': googleTrackerEntry.owner.name,
+        'doubleclick.net': googleTrackerEntry.owner.name,
+        'scorecardresearch.com': 'comScore, Inc',
+        'outbrain.com': 'Outbrain'
+    },
+    entities: {
+        'Google LLC': {
+            domains: [
+                'doubleclick.net',
+                'google.com',
+                'google-analytics.com',
+                'googletagservices.com',
+                'googlesyndication.com'
+            ],
+            prevalence: 79.9,
+            displayName: 'Google'
+        },
+        // 'comScore, Inc' omitted deliberately.
+        Outbrain: {
+            // domains omitted deliberately.
+            prevalence: 79.9,
+            displayName: 'Outbrain'
+        }
+    },
+    trackers: {
+        'google-analytics.com': googleTrackerEntry,
+        'googletagmanager.com': googleTrackerEntry,
+        'googletagservices.com': googleTrackerEntry,
+        'googlesyndication.com': googleTrackerEntry,
+        'doubleclick.net': googleTrackerEntry,
+        'scorecardresearch.com': {
+            owner: {
+                name: 'comScore, Inc',
+                displayName: 'comScore',
+                privacyPolicy: 'https://www.comscore.com/About/Privacy-Policy',
+                url: 'http://comscore.com'
+            },
+            prevalence: 0.102,
+            fingerprinting: 2,
+            cookies: 0.0974,
+            categories: [],
+            default: 'allow',
+            rules: []
+        },
+        'outbrain.com': {
+            owner: {
+                name: 'Outbrain',
+                displayName: 'Outbrain',
+                privacyPolicy: 'https://www.outbrain.com/legal/privacy',
+                url: 'http://outbrain.com'
+            },
+            prevalence: 0.0861,
+            fingerprinting: 2,
+            cookies: 0.079,
+            categories: [],
+            default: 'allow',
+            rules: []
+        }
+    }
+}
+
+const surrogatesConfig = {
+    'google-analytics.com': [
+        ['google-analytics.com/ga.js', 'ga.js'],
+        ['google-analytics.com/analytics.js', 'analytics.js']
+    ],
+    'googletagmanager.com': [
+        ['googletagmanager.com/gtm.js', 'gtm.js']
+    ],
+    'googletagservices.com': [
+        ['googletagservices.com/gpt.js', 'gpt.js'],
+        ['googletagservices.com/tag/js/gpt.js', 'gpt.js']
+    ],
+    'googlesyndication.com': [
+        ['googlesyndication.com/adsbygoogle.js', 'adsbygoogle.js'],
+        ['googlesyndication.com/pagead/js/adsbygoogle.js', 'adsbygoogle.js']
+    ],
+    'doubleclick.net': [
+        ['doubleclick.net/instream/ad_status.js', 'ad_status.js'],
+        ['doubleclick.net/tag/js/gpt.js', 'gpt.js']
+    ],
+    'scorecardresearch.com': [
+        ['scorecardresearch.com/beacon.js', 'beacon.js']
+    ],
+    'outbrain.com': [
+        ['outbrain.com/outbrain.js', 'outbrain.js']
+    ]
+}
+
+describe('Surrogates', () => {
+    it('should return no rules if surrogate configuration is ' +
+       'empty', async () => {
+        assert.deepEqual(
+            await generateTdsRuleset(
+                tds, {}, '/path_prefix/', isRegexSupportedTrue
+            ),
+            { ruleset: [], matchDetailsByRuleId: {} }
+        )
+    })
+
+    it('should generate surrogate redirection rules correctly', async () => {
+        const tdsCopy = JSON.parse(JSON.stringify(tds))
+        const surrogatesConfigCopy =
+              JSON.parse(JSON.stringify(surrogatesConfig))
+
+        assert.deepEqual(
+            await generateTdsRuleset(
+                tds, surrogatesConfig, '/path_prefix/', isRegexSupportedTrue, 13
+            ),
+            {
+                ruleset: [
+                    {
+                        id: 13,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/ga.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||google-analytics.com/ga.js',
+                            isUrlFilterCaseSensitive: false,
+                            excludedInitiatorDomains: [
+                                'doubleclick.net',
+                                'google.com',
+                                'google-analytics.com',
+                                'googletagservices.com',
+                                'googlesyndication.com'
+                            ],
+                            resourceTypes: ['script']
+                        }
+                    },
+                    {
+                        id: 14,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/analytics.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||google-analytics.com/analytics.js',
+                            isUrlFilterCaseSensitive: false,
+                            excludedInitiatorDomains: [
+                                'doubleclick.net',
+                                'google.com',
+                                'google-analytics.com',
+                                'googletagservices.com',
+                                'googlesyndication.com'
+                            ],
+                            resourceTypes: ['script']
+                        }
+                    },
+                    {
+                        id: 15,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/gtm.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||googletagmanager.com/gtm.js',
+                            isUrlFilterCaseSensitive: false,
+                            excludedInitiatorDomains: [
+                                'doubleclick.net',
+                                'google.com',
+                                'google-analytics.com',
+                                'googletagservices.com',
+                                'googlesyndication.com'
+                            ],
+                            resourceTypes: ['script']
+                        }
+                    },
+                    {
+                        id: 16,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/gpt.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||googletagservices.com/gpt.js',
+                            isUrlFilterCaseSensitive: false,
+                            excludedInitiatorDomains: [
+                                'doubleclick.net',
+                                'google.com',
+                                'google-analytics.com',
+                                'googletagservices.com',
+                                'googlesyndication.com'
+                            ],
+                            resourceTypes: ['script']
+                        }
+                    },
+                    {
+                        id: 17,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/gpt.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||googletagservices.com/tag/js/gpt.js',
+                            isUrlFilterCaseSensitive: false,
+                            excludedInitiatorDomains: [
+                                'doubleclick.net',
+                                'google.com',
+                                'google-analytics.com',
+                                'googletagservices.com',
+                                'googlesyndication.com'
+                            ],
+                            resourceTypes: ['script']
+                        }
+                    },
+                    {
+                        id: 18,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/adsbygoogle.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||googlesyndication.com/adsbygoogle.js',
+                            isUrlFilterCaseSensitive: false,
+                            excludedInitiatorDomains: [
+                                'doubleclick.net',
+                                'google.com',
+                                'google-analytics.com',
+                                'googletagservices.com',
+                                'googlesyndication.com'
+                            ],
+                            resourceTypes: ['script']
+                        }
+                    },
+                    {
+                        id: 19,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/adsbygoogle.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||googlesyndication.com/pagead/js/adsbygoogle.js',
+                            isUrlFilterCaseSensitive: false,
+                            excludedInitiatorDomains: [
+                                'doubleclick.net',
+                                'google.com',
+                                'google-analytics.com',
+                                'googletagservices.com',
+                                'googlesyndication.com'
+                            ],
+                            resourceTypes: ['script']
+                        }
+                    },
+                    {
+                        id: 20,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/ad_status.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||doubleclick.net/instream/ad_status.js',
+                            isUrlFilterCaseSensitive: false,
+                            excludedInitiatorDomains: [
+                                'doubleclick.net',
+                                'google.com',
+                                'google-analytics.com',
+                                'googletagservices.com',
+                                'googlesyndication.com'
+                            ],
+                            resourceTypes: ['script']
+                        }
+                    },
+                    {
+                        id: 21,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/gpt.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||doubleclick.net/tag/js/gpt.js',
+                            isUrlFilterCaseSensitive: false,
+                            excludedInitiatorDomains: [
+                                'doubleclick.net',
+                                'google.com',
+                                'google-analytics.com',
+                                'googletagservices.com',
+                                'googlesyndication.com'
+                            ],
+                            resourceTypes: ['script']
+                        }
+                    },
+                    {
+                        id: 22,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/beacon.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||scorecardresearch.com/beacon.js',
+                            isUrlFilterCaseSensitive: false,
+                            domainType: 'thirdParty',
+                            resourceTypes: ['script']
+                        }
+                    },
+                    {
+                        id: 23,
+                        priority: PRIORITY,
+                        action: {
+                            type: 'redirect',
+                            redirect: {
+                                extensionPath: '/path_prefix/outbrain.js'
+                            }
+                        },
+                        condition: {
+                            urlFilter: '||outbrain.com/outbrain.js',
+                            isUrlFilterCaseSensitive: false,
+                            domainType: 'thirdParty',
+                            resourceTypes: ['script']
+                        }
+                    }
+                ],
+                matchDetailsByRuleId: {
+                    13: {
+                        type: 'surrogateScript',
+                        domain: 'google-analytics.com',
+                        rule: 'google-analytics.com/ga.js'
+                    },
+                    14: {
+                        type: 'surrogateScript',
+                        domain: 'google-analytics.com',
+                        rule: 'google-analytics.com/analytics.js'
+                    },
+                    15: {
+                        type: 'surrogateScript',
+                        domain: 'googletagmanager.com',
+                        rule: 'googletagmanager.com/gtm.js'
+                    },
+                    16: {
+                        type: 'surrogateScript',
+                        domain: 'googletagservices.com',
+                        rule: 'googletagservices.com/gpt.js'
+                    },
+                    17: {
+                        type: 'surrogateScript',
+                        domain: 'googletagservices.com',
+                        rule: 'googletagservices.com/tag/js/gpt.js'
+                    },
+                    18: {
+                        type: 'surrogateScript',
+                        domain: 'googlesyndication.com',
+                        rule: 'googlesyndication.com/adsbygoogle.js'
+                    },
+                    19: {
+                        type: 'surrogateScript',
+                        domain: 'googlesyndication.com',
+                        rule: 'googlesyndication.com/pagead/js/adsbygoogle.js'
+                    },
+                    20: {
+                        type: 'surrogateScript',
+                        domain: 'doubleclick.net',
+                        rule: 'doubleclick.net/instream/ad_status.js'
+                    },
+                    21: {
+                        type: 'surrogateScript',
+                        domain: 'doubleclick.net',
+                        rule: 'doubleclick.net/tag/js/gpt.js'
+                    },
+                    22: {
+                        type: 'surrogateScript',
+                        domain: 'scorecardresearch.com',
+                        rule: 'scorecardresearch.com/beacon.js'
+                    },
+                    23: {
+                        type: 'surrogateScript',
+                        domain: 'outbrain.com',
+                        rule: 'outbrain.com/outbrain.js'
+                    }
+                }
+            }
+        )
+
+        // Verify that the configuration wasn't mutated.
+        assert.deepEqual(tds, tdsCopy)
+        assert.deepEqual(surrogatesConfig, surrogatesConfigCopy)
+    })
+})

--- a/test/tds.js
+++ b/test/tds.js
@@ -1,0 +1,55 @@
+const assert = require('assert')
+
+const {
+    generateTdsRuleset
+} = require('../lib/tds')
+
+/** @type Record<string, Array<string, string>[]> */
+const surrogatesConfig = {}
+
+describe('generateTdsRuleset', () => {
+    it('should reject invalid tds.json file', async () => {
+        const invalidBlockLists = [
+            undefined,
+            1,
+            {},
+            { domains: {}, entities: {}, trackers: {} },
+            { cnames: {}, entities: {}, trackers: {} },
+            { cnames: {}, domains: {}, trackers: {} },
+            { cnames: {}, domains: {}, entities: {} },
+            { cnames: 1, domains: 2, entities: 3, trackers: 4 }
+        ]
+
+        for (const blockList of invalidBlockLists) {
+            await assert.rejects(() =>
+                generateTdsRuleset(blockList, surrogatesConfig, '', () => { })
+            )
+        }
+    })
+
+    it('should notice missing isRegexSupported argument', async () => {
+        await assert.rejects(() =>
+            // @ts-expect-error - Missing isRegexSupported argument.
+            generateTdsRuleset(
+                { cnames: {}, domains: {}, entities: {}, trackers: {} }
+            )
+        )
+        await assert.rejects(() =>
+            generateTdsRuleset(
+                { cnames: {}, domains: {}, entities: {}, trackers: {} },
+                // @ts-expect-error - Invalid isRegexSupported argument.
+                surrogatesConfig, '', 3
+            )
+        )
+    })
+
+    it('should reject an invalid surrogates mapping', async () => {
+        await assert.rejects(() =>
+            generateTdsRuleset(
+                { cnames: {}, domains: {}, entities: {}, trackers: {} },
+                // @ts-expect-error - Invalid surrogates argument.
+                null, '', 3
+            )
+        )
+    })
+})


### PR DESCRIPTION
The DuckDuckGo Privacy Essentials browser extension has "surrogate scripts" which are stubbed out placeholders for commonly found third-party scripts. By redirecting requests to those scripts, instead of blocking them outright, some website breakage can be avoided. Those scripts often provide an API on window that websites then assume will always be present. When those APIs aren't found, some websites will fail to work correctly.  Let's add support for generating the necessary redirection rules for those scripts.

Notes:
 - Such redirections sometimes fail in Chrome currently with an "net::ERR_UNSAFE_REDIRECT" error. See https://crbug.com/1361350.
 - These changes are very large. I would have liked to break them down into more manageable chunks, but we're working to a tight internal deadline and I didn't have time.