### PR TITLE
 Add support for "surrogate script" redirection rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,18 @@ Generate a Smarter Encryption ruleset:
 npm run smarter-encryption ../list-of-domains-input.txt ../smarter-encryption-ruleset-output.json
 ```
 
-Generate a Tracker Blocking ruleset:
+Generate the TDS ruleset:
 
 ```bash
-npm run tds ../tds-input.json ../tracker-blocking-ruleset-output.json \
-        [../tracker-domain-by-rule-id-output.txt]
+npm run tds ../tds-input.json ../supported-surrogates-input.json ../tds-ruleset-output.json \
+        [../match-details-by-rule-id-output.json]
 ```
+
+Note:
+ - This includes both Tracker blocking (see [tds.json][3]) and
+   "surrogate script" redirection. (see [tracker-surrogates][4]).
+ - supported-surrogates-input.json must be a JSON encoded array of surrogate
+   script names.
 
 Generate the extension configuration ruleset:
 
@@ -58,3 +64,5 @@ npm test
 
 [1]: https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/
 [2]: https://github.com/duckduckgo/duckduckgo-privacy-extension/
+[3]: https://staticcdn.duckduckgo.com/trackerblocking/v3/tds.json
+[4]: https://github.com/duckduckgo/tracker-surrogates/

--- a/cli.js
+++ b/cli.js
@@ -36,23 +36,37 @@ async function main () {
         }
         break
     case 'tds':
-        if (args.length < 2 || args.length > 3) {
+        if (args.length < 3 || args.length > 4) {
             console.error(
                 'Usage: npm run tds',
-                './tds-input.json ./ruleset-output.json',
-                '[./domain-by-rule-id-output.txt]'
+                './tds-input.json ./supported-surrogates-input.json ',
+                './tds-ruleset-output.json ',
+                '[./match-details-by-rule-id-output.json]'
             )
         } else {
-            const [tdsFilePath, rulesetFilePath, mappingFilePath] = args
+            const [
+                tdsFilePath,
+                supportedSurrogatesPath,
+                rulesetFilePath,
+                mappingFilePath
+            ] = args
 
             const browser = new PuppeteerInterface()
             const isRegexSupported = browser.isRegexSupported.bind(browser)
 
-            const { ruleset, trackerDomainByRuleId } =
+            const { ruleset, matchDetailsByRuleId } =
                   await generateTdsRuleset(
                       JSON.parse(
                           fs.readFileSync(tdsFilePath, { encoding: 'utf8' })
                       ),
+                      new Set(
+                          JSON.parse(
+                              fs.readFileSync(
+                                  supportedSurrogatesPath, { encoding: 'utf8' }
+                              )
+                          )
+                      ),
+                      '/web_accessible_resources/',
                       isRegexSupported
                   )
 
@@ -66,7 +80,7 @@ async function main () {
             if (mappingFilePath) {
                 fs.writeFileSync(
                     mappingFilePath,
-                    trackerDomainByRuleId.join('\n')
+                    JSON.stringify(matchDetailsByRuleId, null, '\t')
                 )
             }
         }
@@ -76,7 +90,7 @@ async function main () {
             console.error(
                 'Usage: npm run extension-configuration',
                 './extension-config-input.json ./ruleset-output.json ',
-                '[./domain-and-reason-by-rule-id-output.json]'
+                '[./match-details-by-rule-id-output.json]'
             )
         } else {
             const [

--- a/lib/tds.js
+++ b/lib/tds.js
@@ -185,7 +185,7 @@ function removeRedundantDNRRules (dnrRules) {
 
 async function generateDNRRulesForTrackerEntry (
     trackerDomain, trackerEntry, requestDomains, excludedInitiatorDomains,
-    priority, isRegexSupported
+    priority, isRegexSupported, surrogatePathPrefix, supportedSurrogateScripts
 ) {
     const dnrRules = []
 
@@ -222,7 +222,8 @@ async function generateDNRRulesForTrackerEntry (
         let {
             action: ruleAction,
             rule: trackerRule,
-            exceptions: ruleExceptions
+            exceptions: ruleExceptions,
+            surrogate
         } = trackerEntryRules[i]
 
         ruleAction = normalizeAction(ruleAction)
@@ -253,24 +254,45 @@ async function generateDNRRulesForTrackerEntry (
             }
         }
 
+        // Handle "surrogate script" redirections.
+        let redirectAction = null
+        /** @type {import('./utils.js').ResourceType[]|null} */
+        let resourceTypes = null
+        if (surrogate) {
+            resourceTypes = ['script']
+            if (!supportedSurrogateScripts.has(surrogate)) {
+                // Block requests if an unsupported surrogate script rule
+                // matches.
+                ruleAction = 'block'
+            } else {
+                ruleAction = 'redirect'
+                redirectAction = {
+                    extensionPath: surrogatePathPrefix + surrogate
+                }
+            }
+        }
+
         priority += TRACKER_RULE_PRIORITY_INCREMENT
         dnrRules.push(
             generateDNRRule({
                 priority,
                 actionType: ruleAction,
+                redirect: redirectAction,
                 urlFilter,
                 regexFilter,
                 matchCase,
                 requestDomains,
-                excludedInitiatorDomains
+                excludedInitiatorDomains,
+                resourceTypes
             })
         )
 
-        if (ruleAction === 'block' && ruleExceptions) {
+        if (ruleExceptions &&
+            (ruleAction === 'block' || ruleAction === 'redirect')) {
             // Incrementing this priority is not necessary since
             // declarativeNetRequest rules with an 'allow' action trump
-            // declarativeNetRequest rules with a 'block' action of the same
-            // priority.
+            // declarativeNetRequest rules with a 'block'/'redirect' action of
+            // the same priority.
             // See https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#matching-algorithm
             dnrRules.push(generateDNRRule({
                 priority,
@@ -292,6 +314,7 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
     const ruleIdByByStringifiedDNRRule = new Map()
     const requestDomainsByRuleId = new Map()
     const trackerDomainsByRuleId = new Map()
+    const matchDetailsByRuleId = {}
 
     // Combine similar rules and create the ruleset.
     const ruleset = []
@@ -303,14 +326,21 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
 
         // Rules without a requestDomains condition definitely can't be
         // combined. Rules other than basic default allow/block almost never
-        // will be in practice. For those cases just add the rule to the ruleset
-        // now.
+        // will be in practice. Surrogate script redirection rules can't be
+        // combined, since the match details type is different. For those cases
+        // just add the rule to the ruleset and match details to the lookup now.
         if (!rule.condition.requestDomains ||
-            rule.priority !== BASELINE_PRIORITY) {
+            rule.priority !== BASELINE_PRIORITY ||
+            rule.action === 'redirect') {
             const ruleId = nextRuleId++
             rule.id = ruleId
             ruleset.push(rule)
-            storeInLookup(trackerDomainsByRuleId, ruleId, [trackerDomain])
+            matchDetailsByRuleId[ruleId] = {
+                type: rule.action.type === 'redirect'
+                    ? 'surrogateScript'
+                    : 'trackerBlocking',
+                possibleTrackerDomains: [trackerDomain]
+            }
             continue
         }
 
@@ -349,29 +379,40 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
         }
     }
 
-    // Create the ruleId -> trackerDomain lookup.
-    const trackerDomainByRuleId = new Array(startingRuleId)
+    // Create the ruleId -> matchDetails lookup.
     for (let i = startingRuleId; i < startingRuleId + ruleset.length; i++) {
-        trackerDomainByRuleId.push(trackerDomainsByRuleId.get(i).join(','))
+        // Entry previously added for uncombinable rule.
+        if (!trackerDomainsByRuleId.has(i)) {
+            continue
+        }
+
+        matchDetailsByRuleId[i] = {
+            type: 'trackerBlocking',
+            possibleTrackerDomains: trackerDomainsByRuleId.get(i)
+        }
     }
 
-    return { ruleset, trackerDomainByRuleId }
+    return { ruleset, matchDetailsByRuleId }
 }
 
 /**
  * @typedef {object} generateTdsRulesetResult
  * @property {import('./utils.js').DNRRule[]} ruleset
  *   The generated Tracker Blocking declarativeNetRequest ruleset.
- * @property {(null|string)[]} trackerDomainByRuleId
- *   Rule ID -> tracker domain mapping. Useful for translating a rule match to
- *   a tracker entry.
+ * @property {object} matchDetailsByRuleId
+ *   Rule ID -> match details.
  */
 
 /**
  * Converts a Tracker Blocking configuration into a declarativeNetRequest
- * ruleset that blocks trackers.
+ * ruleset that blocks/redirects requests to known trackers.
  * @param {object} tds
  *   The Tracker Blocking configuration.
+ * @param {Set<string>} supportedSurrogateScripts
+ *   Known surrogate script filenames.
+ *   Note: Should not include any path part, only the filename.
+ * @param {string} surrogatePathPrefix
+ *   The path prefix for surrogate scripts, e.g. '/web_accessible_resources/'.
  * @param {function} isRegexSupported
  *   A function compatible with chrome.declarativeNetRequest.isRegexSupported.
  *   See https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#method-isRegexSupported
@@ -381,7 +422,8 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
  * @return {Promise<generateTdsRulesetResult>}
  */
 async function generateTdsRuleset (
-    tds, isRegexSupported, startingRuleId = 1
+    tds, supportedSurrogateScripts, surrogatePathPrefix, isRegexSupported,
+    startingRuleId = 1
 ) {
     if (typeof tds !== 'object' ||
         typeof tds.cnames !== 'object' || typeof tds.domains !== 'object' ||
@@ -451,7 +493,8 @@ async function generateTdsRuleset (
         const priority = priorityByTrackerDomain.get(trackerDomain)
         for (const rule of await generateDNRRulesForTrackerEntry(
             trackerDomain, trackerEntry, requestDomains,
-            excludedInitiatorDomains, priority, isRegexSupported)
+            excludedInitiatorDomains, priority, isRegexSupported,
+            surrogatePathPrefix, supportedSurrogateScripts)
         ) {
             // Probably better to throw early, than to worry about the unlikely
             // situation where regular expression rules are combined to bring


### PR DESCRIPTION
The DuckDuckGo Privacy Essentials browser extension has "surrogate
scripts" which are stubbed out placeholders for commonly found
third-party scripts. By redirecting requests to those scripts, instead
of blocking them outright, some website breakage can be avoided. Those
scripts often provide an API on window that websites then assume will
always be present. When those APIs aren't found, some websites will
fail to work correctly.  Let's add support for generating the
necessary redirection rules for those scripts.

Note:
 - Such redirections sometimes fail in Chrome currently with an
   "net::ERR_UNSAFE_REDIRECT" error. See https://crbug.com/1361350.