### PR TITLE
Disable macos-latest GitHub runner for now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node: [16.x, 18.x]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest] # FIXME - macos-latest runner keeps failing
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}


### PR DESCRIPTION
For some reason, the test are failing intermittently when run by GitHub's macOS test runner. Let's disable the macOS runner for now, we can re-enable it again when we (or GitHub) get to the bottom of the problem.