### PR TITLE
Specify the priority for extension-state based rules

### DIFF
--- a/lib/rulePriorities.js
+++ b/lib/rulePriorities.js
@@ -1,0 +1,8 @@
+/** @module rulePriorities */
+
+// Note: Rule priorities for configuration associated rules are kept in the
+//       ddg2dnr respective modules. Rule priorities are only added here when
+//       there is not a better place to put them.
+
+exports.AD_ATTRIBUTION_POLICY_PRIORITY = 20000
+exports.USER_ALLOWLISTED_PRIORITY = 1000000

--- a/test/rulePriorities.js
+++ b/test/rulePriorities.js
@@ -14,6 +14,11 @@ const {
     CEILING_PRIORITY: TRACKER_ALLOWLIST_CEILING_PRIORITY
 } = require('../lib/trackerAllowlist')
 
+const {
+    AD_ATTRIBUTION_POLICY_PRIORITY,
+    USER_ALLOWLISTED_PRIORITY
+} = require('../lib/rulePriorities')
+
 describe('Rule Priorities', () => {
     it('correct relative rule priorities', () => {
         // Tracker Blocking priorities.
@@ -25,6 +30,10 @@ describe('Rule Priorities', () => {
         assert.ok(TRACKER_ALLOWLIST_BASELINE_PRIORITY >
                   TRACKER_BLOCKING_CEILING_PRIORITY)
 
+        // Extension state rule priorities.
+        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY >
+                 TRACKER_BLOCKING_CEILING_PRIORITY)
+
         // Smarter Encryption priority.
         // Note: It's important that the Smarter Encryption rule priority is
         //       higher than the priority for Tracker Blocking etc rules.
@@ -34,5 +43,11 @@ describe('Rule Priorities', () => {
         //       will no longer have the opportunity to match.
         assert.ok(SMARTER_ENCRYPTION_PRIORITY >
                   TRACKER_ALLOWLIST_CEILING_PRIORITY)
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY >
+                 AD_ATTRIBUTION_POLICY_PRIORITY)
+
+        // If the user disables protections for a website, that should take
+        // precedence over everything else.
+        assert.ok(USER_ALLOWLISTED_PRIORITY > SMARTER_ENCRYPTION_PRIORITY)
     })
 })


### PR DESCRIPTION
Some declarativeNetRequest rules that the DuckDuckGo extension generates do not relate directly to an extension
configuration (e.g. the block list), but rather to the extension's state (e.g. the user clicked to allowlist a website). Let's add a place to put the priorities for those rules, so that the relative priorities for all declarativeNetRequest rules can be properly tested.