### PR TITLE
Ignore tracker entries and rules with unknown actions

### DIFF
--- a/lib/tds.js
+++ b/lib/tds.js
@@ -81,14 +81,16 @@ function normalizeTypesCondition (types) {
     return Array.from(normalizedTypes)
 }
 
-function normalizeAction (action) {
-    switch (action) {
-    case 'ignore':
-    case 'allow':
+function normalizeAction (action, defaultAction) {
+    if (action === 'ignore') {
         return 'allow'
-    default:
-        return 'block'
     }
+
+    if (!action && defaultAction) {
+        return defaultAction
+    }
+
+    return action
 }
 
 function normalizeTrackerRule (trackerRule) {
@@ -194,6 +196,13 @@ async function generateDNRRulesForTrackerEntry (
     }
 
     const defaultAction = normalizeAction(trackerEntry.default)
+
+    // Default action is required and must be either 'block' or
+    // 'allow' (aka 'ignore').
+    if (defaultAction !== 'allow' && defaultAction !== 'block') {
+        return dnrRules
+    }
+
     const trackerEntryRules = trackerEntry.rules || []
 
     // Create the declarativeNetRequest rule for the tracker entry's default
@@ -226,7 +235,15 @@ async function generateDNRRulesForTrackerEntry (
             surrogate
         } = trackerEntryRules[i]
 
-        ruleAction = normalizeAction(ruleAction)
+        ruleAction = normalizeAction(ruleAction, 'block')
+
+        // So far, only 'block' and 'allow' (aka 'ignore') actions are supported
+        // for tracker rules. In the future, additional actions for
+        // Click to Load will be supported too.
+        if (ruleAction !== 'block' && ruleAction !== 'allow') {
+            continue
+        }
+
         trackerRule = normalizeTrackerRule(trackerRule)
 
         let {

--- a/test/tds.js
+++ b/test/tds.js
@@ -1415,4 +1415,140 @@ describe('generateTdsRuleset', () => {
             }
         })
     })
+
+    it('should ignore rules with an unknown action', async () => {
+        const randAction = () => Math.random().toString()
+
+        const blockList = emptyBlockList()
+        addDomain(blockList, 'default-ignore.invalid', 'Default Ignore entity', 'ignore', [
+            {
+                rule: 'default-ignore\\.invalid\\/known-action-1'
+            },
+            {
+                rule: 'default-ignore\\.invalid\\/unknown-action-1',
+                action: randAction()
+            },
+            {
+                rule: 'default-ignore\\.invalid\\/known-action-3',
+                exceptions: { types: ['script'] }
+            },
+            {
+                rule: 'default-ignore\\.invalid\\/unknown-action-2',
+                action: randAction(),
+                exceptions: { types: ['script'] }
+            }
+        ])
+        addDomain(blockList, 'default-block.invalid', 'Default Block entity', 'block', [
+            {
+                rule: 'default-block\\.invalid\\/known-action-1'
+            },
+            {
+                rule: 'default-block\\.invalid\\/unknown-action-1',
+                action: randAction()
+            },
+            {
+                rule: 'default-block\\.invalid\\/known-action-2',
+                exceptions: { types: ['script'] }
+            },
+            {
+                rule: 'default-block\\.invalid\\/unknown-action-2',
+                action: randAction(),
+                exceptions: { types: ['script'] }
+            }
+        ])
+        addDomain(blockList, 'default-unknown.invalid', 'Default Unknown entity', randAction(), [
+            {
+                rule: 'default-unknown\\.invalid\\/known-action-1'
+            },
+            {
+                rule: 'default-unknown\\.invalid\\/unknown-action-1',
+                action: randAction()
+            },
+            {
+                rule: 'default-unknown\\.invalid\\/known-action-2',
+                exceptions: { types: ['script'] }
+            },
+            {
+                rule: 'default-unknown\\.invalid\\/unknown-action-2',
+                action: randAction(),
+                exceptions: { types: ['script'] }
+            }
+        ])
+
+        await rulesetEqual(blockList, isRegexSupportedTrue, null, {
+            expectedRuleset: [
+                {
+                    id: 1,
+                    priority: 10001,
+                    action: {
+                        type: 'block'
+                    },
+                    condition: {
+                        domainType: 'thirdParty',
+                        isUrlFilterCaseSensitive: false,
+                        urlFilter: '||default-ignore.invalid/known-action-3'
+                    }
+                },
+                {
+                    id: 2,
+                    priority: 10001,
+                    action: {
+                        type: 'allow'
+                    },
+                    condition: {
+                        isUrlFilterCaseSensitive: false,
+                        resourceTypes: ['script'],
+                        urlFilter: '||default-ignore.invalid/known-action-3'
+                    }
+                },
+                {
+                    id: 3,
+                    priority: 10002,
+                    action: {
+                        type: 'block'
+                    },
+                    condition: {
+                        domainType: 'thirdParty',
+                        isUrlFilterCaseSensitive: false,
+                        urlFilter: '||default-ignore.invalid/known-action-1'
+                    }
+                },
+                {
+                    id: 4,
+                    priority: 10000,
+                    action: {
+                        type: 'block'
+                    },
+                    condition: {
+                        domainType: 'thirdParty',
+                        requestDomains: ['default-block.invalid']
+                    }
+                },
+                {
+                    id: 5,
+                    priority: 10001,
+                    action: {
+                        type: 'allow'
+                    },
+                    condition: {
+                        isUrlFilterCaseSensitive: false,
+                        resourceTypes: ['script'],
+                        urlFilter: '||default-block.invalid/known-action-2'
+                    }
+                },
+                {
+                    id: 6,
+                    priority: 10002,
+                    action: {
+                        type: 'block'
+                    },
+                    condition: {
+                        domainType: 'thirdParty',
+                        isUrlFilterCaseSensitive: false,
+                        urlFilter: '||default-block.invalid/known-action-1'
+                    }
+                }
+            ]
+        })
+    })
 })


### PR DESCRIPTION
Tracker entries always need a default action of either 'ignore' (becoming 'allow' for declarativeNetRequest) or 'block'.

Tracker rules have the default action of 'block', but still for now must have an action of either 'ignore' or 'block. In the future, there will be more supported actions for tracker rules, for example special actions for the "Click to Load" feature.

Take care to drop tracker rules and entries that have unknown actions. That way the block list can be updated, without unsupported rule actions from resulting in incorrect request block/allow outcomes.