### PR TITLE
Add contentBlocking, unprotectedTemporary and denylisting support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -107,6 +107,7 @@ async function main () {
                               extensionConfigFilePath, { encoding: 'utf8' }
                           )
                       ),
+                      [],
                       isRegexSupported
                   )
 

--- a/lib/extensionConfiguration.js
+++ b/lib/extensionConfiguration.js
@@ -1,6 +1,7 @@
 /** @module extensionConfiguration */
 
 const { generateTrackerAllowlistRules } = require('./trackerAllowlist')
+const { generateTemporaryAllowlistRules } = require('./temporaryAllowlist')
 
 /**
  * @typedef {object} generateExtensionConfigurationRulesetResult
@@ -14,6 +15,9 @@ const { generateTrackerAllowlistRules } = require('./trackerAllowlist')
  * Generated an extension configuration declarativeNetRequest ruleset.
  * @param {object} extensionConfig
  *   The extension configuration.
+ * @param {string[]} denylistedDomains
+ *   Domains that the user has specifically denylisted. These domains should be
+ *   excluded from any contentBlocking/unprotectedTemporary allowlisting rules.
  * @param {function} isRegexSupported
  *   A function compatible with chrome.declarativeNetRequest.isRegexSupported.
  *   See https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#method-isRegexSupported
@@ -24,7 +28,7 @@ const { generateTrackerAllowlistRules } = require('./trackerAllowlist')
  */
 
 async function generateExtensionConfigurationRuleset (
-    extensionConfig, isRegexSupported, startingRuleId = 1
+    extensionConfig, denylistedDomains, isRegexSupported, startingRuleId = 1
 ) {
     if (typeof isRegexSupported !== 'function') {
         throw new Error('Missing isRegexSupported function.')
@@ -34,14 +38,23 @@ async function generateExtensionConfigurationRuleset (
     const ruleset = []
     const matchDetailsByRuleId = {}
 
+    const appendRuleResult = result => {
+        if (result) {
+            const { matchDetails, rule } = result
+            rule.id = ruleId++
+            ruleset.push(rule)
+            matchDetailsByRuleId[rule.id] = matchDetails
+        }
+    }
+
     // Tracker Allowlist.
     for (const result of generateTrackerAllowlistRules(extensionConfig)) {
-        if (!result) continue
+        appendRuleResult(result)
+    }
 
-        const [rule, matchDetails] = result
-        rule.id = ruleId++
-        ruleset.push(rule)
-        matchDetailsByRuleId[rule.id] = matchDetails
+    // Content Blocking and Unprotected Temporary allowlists.
+    for (const result of generateTemporaryAllowlistRules(extensionConfig, denylistedDomains)) {
+        appendRuleResult(result)
     }
 
     return { ruleset, matchDetailsByRuleId }

--- a/lib/temporaryAllowlist.js
+++ b/lib/temporaryAllowlist.js
@@ -1,0 +1,65 @@
+/** @module temporaryAllowlist */
+
+// The contentBlocking allowlist only disables tracker blocking for a website.
+const CONTENT_BLOCKING_ALLOWLIST_PRIORITY = 20000
+// The unprotectedTemporary allowlist disables all protections for a website.
+const UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY = 1000000
+
+const {
+    generateDNRRule
+} = require('./utils')
+
+/**
+ * @typedef generateTemporaryAllowlistRulesResult
+ * @property {import('./utils').DNRRule} rule
+ * @property {object} matchDetails
+ */
+
+/**
+ * Generator to produce the declarativeNetRequest rules and corresponding match
+ * details for the unprotectedTemporary and contentBlocking sections of the
+ * extension configuration.
+ * @param {object} extensionConfiguration
+ *   The extension configuration.
+ * @return {Generator<generateTemporaryAllowlistRulesResult>}
+ */
+function* generateTemporaryAllowlistRules (
+    { features: { contentBlocking }, unprotectedTemporary }, denylistedDomains
+) {
+    const denylistedDomainsSet = new Set(denylistedDomains)
+
+    const configs = [{
+        type: 'unprotectedTemporary',
+        priority: UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY,
+        entries: unprotectedTemporary || []
+    }]
+
+    if (contentBlocking && contentBlocking.state === 'enabled') {
+        configs.push({
+            type: 'contentBlocking',
+            priority: CONTENT_BLOCKING_ALLOWLIST_PRIORITY,
+            entries: contentBlocking.exceptions || []
+        })
+    }
+
+    for (const { type, priority, entries } of configs) {
+        for (const { domain, reason } of entries) {
+            if (denylistedDomainsSet.has(domain)) continue
+
+            const matchDetails = { type, domain, reason }
+            const rule = generateDNRRule({
+                priority,
+                actionType: 'allowAllRequests',
+                requestDomains: [domain],
+                resourceTypes: ['main_frame']
+            })
+            yield { rule, matchDetails }
+        }
+    }
+}
+
+exports.CONTENT_BLOCKING_ALLOWLIST_PRIORITY =
+    CONTENT_BLOCKING_ALLOWLIST_PRIORITY
+exports.UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY =
+    UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY
+exports.generateTemporaryAllowlistRules = generateTemporaryAllowlistRules

--- a/lib/trackerAllowlist.js
+++ b/lib/trackerAllowlist.js
@@ -22,11 +22,17 @@ const MAXIMUM_RULES_PER_TRACKER_ENTRY = (CEILING_PRIORITY - BASELINE_PRIORITY) /
                                             PRIORITY_INCREMENT
 
 /**
+ * @typedef generateTrackerAllowlistRulesResult
+ * @property {import('./utils').DNRRule} rule
+ * @property {object} matchDetails
+ */
+
+/**
  * Generator to produce the declarativeNetRequest rules and corresponding match
  * details for the given trackerAllowlist configuration.
  * @param {object} extensionConfiguration
  *   The extension configuration.
- * @return {Generator<[import('./utils').DNRRule, object]>}
+ * @return {Generator<generateTrackerAllowlistRulesResult>}
  */
 function* generateTrackerAllowlistRules ({ features: { trackerAllowlist } }) {
     // No allowlisted trackers.
@@ -118,7 +124,7 @@ function* generateTrackerAllowlistRules ({ features: { trackerAllowlist } }) {
                 reason: allowlistReason
             }
 
-            yield [rule, matchDetails]
+            yield { rule, matchDetails }
 
             priority += PRIORITY_INCREMENT
         }

--- a/test/extensionConfiguration.js
+++ b/test/extensionConfiguration.js
@@ -7,20 +7,20 @@ const {
 describe('generateExtensionConfigurationRuleset', () => {
     it('should reject invalid extension configuration', async () => {
         await assert.rejects(() =>
-            generateExtensionConfigurationRuleset(null, () => { })
+            generateExtensionConfigurationRuleset(null, [], () => { })
         )
         await assert.rejects(() =>
-            generateExtensionConfigurationRuleset({}, () => { })
+            generateExtensionConfigurationRuleset({}, [], () => { })
         )
         await assert.rejects(() =>
             generateExtensionConfigurationRuleset({
                 features: null
-            }, () => { })
+            }, [], () => { })
         )
         await assert.doesNotReject(() =>
             generateExtensionConfigurationRuleset({
                 features: {}
-            }, () => { })
+            }, [], () => { })
         )
     })
 
@@ -29,11 +29,12 @@ describe('generateExtensionConfigurationRuleset', () => {
             // @ts-expect-error - Missing isRegexSupported argument.
             generateExtensionConfigurationRuleset({
                 features: {}
-            })
+            }, [])
         )
         await assert.rejects(() =>
             generateExtensionConfigurationRuleset(
                 { features: {} },
+                [],
                 // @ts-expect-error - Invalid isRegexSupported argument.
                 3
             )
@@ -41,7 +42,7 @@ describe('generateExtensionConfigurationRuleset', () => {
         await assert.doesNotReject(() =>
             generateExtensionConfigurationRuleset({
                 features: {}
-            }, () => { })
+            }, [], () => { })
         )
     })
 })

--- a/test/rulePriorities.js
+++ b/test/rulePriorities.js
@@ -15,6 +15,11 @@ const {
 } = require('../lib/trackerAllowlist')
 
 const {
+    CONTENT_BLOCKING_ALLOWLIST_PRIORITY,
+    UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY
+} = require('../lib/temporaryAllowlist')
+
+const {
     AD_ATTRIBUTION_POLICY_PRIORITY,
     USER_ALLOWLISTED_PRIORITY
 } = require('../lib/rulePriorities')
@@ -30,9 +35,12 @@ describe('Rule Priorities', () => {
         assert.ok(TRACKER_ALLOWLIST_BASELINE_PRIORITY >
                   TRACKER_BLOCKING_CEILING_PRIORITY)
 
-        // Extension state rule priorities.
-        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY >
-                 TRACKER_BLOCKING_CEILING_PRIORITY)
+        // Content Blocking allowlist and ad attribution allowlisting rules
+        // should disable Tracker Blocking, but not other protections.
+        assert.ok(CONTENT_BLOCKING_ALLOWLIST_PRIORITY >
+                  TRACKER_BLOCKING_CEILING_PRIORITY)
+        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY ===
+                  CONTENT_BLOCKING_ALLOWLIST_PRIORITY)
 
         // Smarter Encryption priority.
         // Note: It's important that the Smarter Encryption rule priority is
@@ -45,9 +53,16 @@ describe('Rule Priorities', () => {
                   TRACKER_ALLOWLIST_CEILING_PRIORITY)
         assert.ok(SMARTER_ENCRYPTION_PRIORITY >
                  AD_ATTRIBUTION_POLICY_PRIORITY)
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY >
+                  CONTENT_BLOCKING_ALLOWLIST_PRIORITY)
 
-        // If the user disables protections for a website, that should take
-        // precedence over everything else.
-        assert.ok(USER_ALLOWLISTED_PRIORITY > SMARTER_ENCRYPTION_PRIORITY)
+        // Unprotected Temporary allowlist and user allowlist should disable all
+        // protections.
+        assert.ok(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY >
+                  TRACKER_BLOCKING_CEILING_PRIORITY)
+        assert.ok(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY >
+                  SMARTER_ENCRYPTION_PRIORITY)
+        assert.ok(USER_ALLOWLISTED_PRIORITY ===
+                  UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY)
     })
 })

--- a/test/temporaryAllowlist.js
+++ b/test/temporaryAllowlist.js
@@ -1,0 +1,215 @@
+const assert = require('assert')
+
+const {
+    CONTENT_BLOCKING_ALLOWLIST_PRIORITY,
+    UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY
+} = require('../lib/temporaryAllowlist')
+
+const {
+    generateExtensionConfigurationRuleset
+} = require('../lib/extensionConfiguration')
+
+async function isRegexSupportedTrue ({ regex, isCaseSensitive }) {
+    return { isSupported: true }
+}
+
+const baseExtensionConfigStringifed = JSON.stringify({
+    features: {
+        contentBlocking: {
+            state: 'enabled',
+            exceptions: [{
+                domain: 'content-blocking1.example',
+                reason: 'First contentBlocking reason'
+            }, {
+                domain: 'content-blocking2.example',
+                reason: 'Second contentBlocking reason'
+            }]
+        }
+    },
+    unprotectedTemporary: [{
+        domain: 'unprotected-temporary1.example',
+        reason: 'First unprotectedTemporary reason'
+    }, {
+        domain: 'unprotected-temporary2.example',
+        reason: 'Second unprotectedTemporary reason'
+    }]
+})
+
+async function rulesetEqual (
+    extensionConfig, denylistedDomains, expectedRuleset, expectedLookup
+) {
+    const extensionConfigBefore = JSON.stringify(extensionConfig)
+
+    const {
+        ruleset: actualRuleset,
+        matchDetailsByRuleId: actualLookup
+    } = await generateExtensionConfigurationRuleset(
+        extensionConfig, denylistedDomains, isRegexSupportedTrue
+    )
+
+    assert.deepEqual(actualRuleset, expectedRuleset)
+    assert.deepEqual(actualLookup, expectedLookup)
+
+    // Verify the extension config wasn't mutated.
+    assert.deepEqual(extensionConfig, JSON.parse(extensionConfigBefore))
+}
+
+describe('Temporary Allowlist', () => {
+    it('should generate allowlisting rules correctly', async () => {
+        const extensionConfig = JSON.parse(baseExtensionConfigStringifed)
+
+        await rulesetEqual(
+            extensionConfig,
+            [],
+            [
+                {
+                    id: 1,
+                    priority: UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY,
+                    condition: {
+                        requestDomains: [
+                            'unprotected-temporary1.example'
+                        ],
+                        resourceTypes: [
+                            'main_frame'
+                        ]
+                    },
+                    action: {
+                        type: 'allowAllRequests'
+                    }
+                },
+                {
+                    id: 2,
+                    priority: UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY,
+                    condition: {
+                        requestDomains: [
+                            'unprotected-temporary2.example'
+                        ],
+                        resourceTypes: [
+                            'main_frame'
+                        ]
+                    },
+                    action: {
+                        type: 'allowAllRequests'
+                    }
+                },
+                {
+                    id: 3,
+                    priority: CONTENT_BLOCKING_ALLOWLIST_PRIORITY,
+                    condition: {
+                        requestDomains: [
+                            'content-blocking1.example'
+                        ],
+                        resourceTypes: [
+                            'main_frame'
+                        ]
+                    },
+                    action: {
+                        type: 'allowAllRequests'
+                    }
+                },
+                {
+                    id: 4,
+                    priority: CONTENT_BLOCKING_ALLOWLIST_PRIORITY,
+                    condition: {
+                        requestDomains: [
+                            'content-blocking2.example'
+                        ],
+                        resourceTypes: [
+                            'main_frame'
+                        ]
+                    },
+                    action: {
+                        type: 'allowAllRequests'
+                    }
+                }
+            ],
+            {
+                1: {
+                    type: 'unprotectedTemporary',
+                    domain: 'unprotected-temporary1.example',
+                    reason: 'First unprotectedTemporary reason'
+                },
+                2: {
+                    type: 'unprotectedTemporary',
+                    domain: 'unprotected-temporary2.example',
+                    reason: 'Second unprotectedTemporary reason'
+                },
+                3: {
+                    type: 'contentBlocking',
+                    domain: 'content-blocking1.example',
+                    reason: 'First contentBlocking reason'
+                },
+                4: {
+                    type: 'contentBlocking',
+                    domain: 'content-blocking2.example',
+                    reason: 'Second contentBlocking reason'
+                }
+            }
+        )
+    })
+
+    it('shouldn\'t generate contentBlocking rules if disabled', async () => {
+        const extensionConfig = JSON.parse(baseExtensionConfigStringifed)
+        extensionConfig.features.contentBlocking.state = 'disabled'
+        delete extensionConfig.unprotectedTemporary
+
+        await rulesetEqual(extensionConfig, [], [], {})
+    })
+
+    it('shouldn\'t generate rules for denylisted domains', async () => {
+        const extensionConfig = JSON.parse(baseExtensionConfigStringifed)
+
+        await rulesetEqual(
+            extensionConfig,
+            [
+                'content-blocking2.example',
+                'different-domain.example',
+                'unprotected-temporary1.example'
+            ],
+            [
+                {
+                    id: 1,
+                    priority: UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY,
+                    condition: {
+                        requestDomains: [
+                            'unprotected-temporary2.example'
+                        ],
+                        resourceTypes: [
+                            'main_frame'
+                        ]
+                    },
+                    action: {
+                        type: 'allowAllRequests'
+                    }
+                },
+                {
+                    id: 2,
+                    priority: CONTENT_BLOCKING_ALLOWLIST_PRIORITY,
+                    condition: {
+                        requestDomains: [
+                            'content-blocking1.example'
+                        ],
+                        resourceTypes: [
+                            'main_frame'
+                        ]
+                    },
+                    action: {
+                        type: 'allowAllRequests'
+                    }
+                }
+            ],
+            {
+                1: {
+                    type: 'unprotectedTemporary',
+                    domain: 'unprotected-temporary2.example',
+                    reason: 'Second unprotectedTemporary reason'
+                },
+                2: {
+                    type: 'contentBlocking',
+                    domain: 'content-blocking1.example',
+                    reason: 'First contentBlocking reason'
+                }
+            }
+        )
+    })
+})

--- a/test/trackerAllowlist.js
+++ b/test/trackerAllowlist.js
@@ -39,7 +39,7 @@ describe('Tracker Allowlist', () => {
 
         await assert.doesNotReject(() =>
             generateExtensionConfigurationRuleset(
-                extensionConfig, isRegexSupportedTrue
+                extensionConfig, [], isRegexSupportedTrue
             )
         )
 
@@ -48,6 +48,7 @@ describe('Tracker Allowlist', () => {
         await assert.rejects(() =>
             generateExtensionConfigurationRuleset(
                 extensionConfig,
+                [],
                 isRegexSupportedTrue
             )
         )
@@ -60,7 +61,7 @@ describe('Tracker Allowlist', () => {
                 features: {
                     trackerAllowlist: {}
                 }
-            }, isRegexSupportedTrue),
+            }, [], isRegexSupportedTrue),
             { ruleset: [], matchDetailsByRuleId: {} }
         )
 
@@ -82,7 +83,7 @@ describe('Tracker Allowlist', () => {
                         }
                     }
                 }
-            }, isRegexSupportedTrue),
+            }, [], isRegexSupportedTrue),
             { ruleset: [], matchDetailsByRuleId: {} }
         )
 
@@ -96,7 +97,7 @@ describe('Tracker Allowlist', () => {
                         }
                     }
                 }
-            }, isRegexSupportedTrue),
+            }, [], isRegexSupportedTrue),
             { ruleset: [], matchDetailsByRuleId: {} }
         )
     })
@@ -158,7 +159,7 @@ describe('Tracker Allowlist', () => {
 
         assert.deepEqual(
             await generateExtensionConfigurationRuleset(
-                extensionConfig, isRegexSupportedTrue, 23
+                extensionConfig, [], isRegexSupportedTrue, 23
             ),
             {
                 ruleset: [


### PR DESCRIPTION
Add contentBlocking, unprotectedTemporary and denylisting support

The extension configuration (extension-config.json) has several
different ways for privacy protections to be disabled for a
website. Important for when a website is broken by our protections. We
need to support those for Chrome MV3. So far, we support the
trackerAllowlist[1], but not the contentBlocking[2] or
unprotectedTemporary[3] allowlists.

Furthermore, the user is allowed to override the contentBlocking and
unprotectedTemporary allowlists by "denylisting" a website. We need to
add Chrome MV3 support for that too.

1 - https://github.com/duckduckgo/privacy-configuration/blob/main/features/tracker-allowlist.json
2 - https://github.com/duckduckgo/privacy-configuration/blob/main/features/content-blocking.json
3 - https://github.com/duckduckgo/privacy-configuration/blob/main/features/unprotected-temporary.json