### PR TITLE
Add rule priority for allowing ServiceWorker initiated requests

### DIFF
--- a/lib/rulePriorities.js
+++ b/lib/rulePriorities.js
@@ -5,4 +5,5 @@
 //       there is not a better place to put them.
 
 exports.AD_ATTRIBUTION_POLICY_PRIORITY = 20000
+exports.SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY = 1000000
 exports.USER_ALLOWLISTED_PRIORITY = 1000000

--- a/test/rulePriorities.js
+++ b/test/rulePriorities.js
@@ -25,6 +25,7 @@ const {
 
 const {
     AD_ATTRIBUTION_POLICY_PRIORITY,
+    SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY,
     USER_ALLOWLISTED_PRIORITY
 } = require('../lib/rulePriorities')
 
@@ -64,14 +65,17 @@ describe('Rule Priorities', () => {
                   CONTENT_BLOCKING_ALLOWLIST_PRIORITY)
 
         // Unprotected Temporary allowlist and user allowlist should disable all
-        // protections.
+        // protections. All protections should also be disabled for
+        // ServiceWorker initiated requests.
         assert.ok(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY >
                   TRACKER_BLOCKING_CEILING_PRIORITY)
         assert.ok(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY >
                   SMARTER_ENCRYPTION_PRIORITY)
-        assert.ok(USER_ALLOWLISTED_PRIORITY ===
-                  UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY)
         assert.ok(USER_ALLOWLISTED_PRIORITY >
                   GPC_HEADER_PRIORITY)
+        assert.ok(USER_ALLOWLISTED_PRIORITY ===
+                  UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY)
+        assert.ok(USER_ALLOWLISTED_PRIORITY ===
+                  SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY)
     })
 })


### PR DESCRIPTION
We do not block ServiceWorker initiated requests yet, as doing so led
to major website breakage in the past. We're going to implement that
for Chrome MV3 with an allowing rule that matches tabs with an ID of
-1. For that, we will need a rule priority that is higher than the
blocking/redirecting rules of our protections.