### PR TITLE
Expand generateDNRRule for GPC protection rules

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,10 +67,12 @@ function storeInLookup (lookup, key, values) {
  * @property {number} priority
  * @property {DNRRuleActionType} actionType
  * @property {object} [redirect]
+ * @property {object[]} [requestHeaders]
+ * @property {object[]} [responseHeaders]
  * @property {string} [urlFilter]
  * @property {string} [regexFilter]
  * @property {ResourceType[]|null} [resourceTypes]
- * @property {string[]} requestDomains
+ * @property {string[]} [requestDomains]
  * @property {string[]} [excludedRequestDomains]
  * @property {string[]} [initiatorDomains]
  * @property {string[]} [excludedInitiatorDomains]
@@ -83,9 +85,10 @@ function storeInLookup (lookup, key, values) {
  * @return {DNRRule}
  */
 function generateDNRRule ({
-    id, priority, actionType, redirect, urlFilter, regexFilter, resourceTypes,
-    requestDomains, excludedRequestDomains, initiatorDomains,
-    excludedInitiatorDomains, matchCase = false
+    id, priority, actionType, redirect, requestHeaders, responseHeaders,
+    urlFilter, regexFilter, resourceTypes, requestDomains,
+    excludedRequestDomains, initiatorDomains, excludedInitiatorDomains,
+    matchCase = false
 }) {
     /** @type {DNRRule} */
     const dnrRule = {
@@ -94,7 +97,6 @@ function generateDNRRule ({
             type: actionType
         },
         condition: {
-            requestDomains
         }
     }
 
@@ -102,8 +104,21 @@ function generateDNRRule ({
         dnrRule.id = id
     }
 
+    if (requestDomains && requestDomains.length > 0) {
+        dnrRule.condition.requestDomains = requestDomains
+    }
+
     if (actionType === 'redirect' && redirect) {
         dnrRule.action.redirect = redirect
+    }
+
+    if (actionType === 'modifyHeaders') {
+        if (requestHeaders && requestHeaders.length > 0) {
+            dnrRule.action.requestHeaders = requestHeaders
+        }
+        if (responseHeaders && responseHeaders.length > 0) {
+            dnrRule.action.responseHeaders = responseHeaders
+        }
     }
 
     if (urlFilter) {
@@ -150,7 +165,7 @@ function generateDNRRule ({
         excludedInitiatorDomains.length > 0 &&
         actionType !== 'allow') {
         if (excludedInitiatorDomains.length === 1 &&
-            requestDomains.length === 1) {
+            requestDomains && requestDomains.length === 1) {
             // Assume that if only one initiator domain is excluded (and there
             // is only one request domain), that the excluded initiator domain
             // is the same as the request domain.


### PR DESCRIPTION
The generateDNRRule rule was originally just for generating the
declarativeNetRequest rules necessary for Tracker Blocking. As we
expand to include more privacy features, more rule actions and
conditions need to be supported. Jason is working on adding GPC[1]
protection now, but for that he needs to omit the requestDomains
condition and to specify header modifying actions.

1 - https://help.duckduckgo.com/duckduckgo-help-pages/privacy/gpc/
