### PR TITLE
Add generateDNRRule support for tabIds and requestMethods conditions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,12 +72,17 @@ function storeInLookup (lookup, key, values) {
  * @property {object[]} [responseHeaders]
  * @property {string} [urlFilter]
  * @property {string} [regexFilter]
- * @property {ResourceType[]|null} [resourceTypes]
+ * @property {ResourceType[] | null} [resourceTypes]
+ * @property {ResourceType[] | null} [excludedResourceTypes]
  * @property {string[]} [requestDomains]
  * @property {string[]} [excludedRequestDomains]
  * @property {string[]} [initiatorDomains]
  * @property {string[]} [excludedInitiatorDomains]
  * @property {boolean} [matchCase]
+ * @property {number[]} [tabIds]
+ * @property {number[]} [excludedTabIds]
+ * @property {RequestMethod[]} [requestMethods]
+ * @property {RequestMethod[]} [excludedRequestMethods]
  */
 
 /**
@@ -87,9 +92,10 @@ function storeInLookup (lookup, key, values) {
  */
 function generateDNRRule ({
     id, priority, actionType, redirect, requestHeaders, responseHeaders,
-    urlFilter, regexFilter, resourceTypes, requestDomains,
-    excludedRequestDomains, initiatorDomains, excludedInitiatorDomains,
-    matchCase = false
+    urlFilter, regexFilter, resourceTypes, excludedResourceTypes,
+    requestDomains, excludedRequestDomains, initiatorDomains,
+    excludedInitiatorDomains, matchCase = false, tabIds, excludedTabIds,
+    requestMethods, excludedRequestMethods
 }) {
     /** @type {DNRRule} */
     const dnrRule = {
@@ -152,6 +158,10 @@ function generateDNRRule ({
         dnrRule.condition.resourceTypes = resourceTypes
     }
 
+    if (excludedResourceTypes && excludedResourceTypes.length > 0) {
+        dnrRule.condition.excludedResourceTypes = excludedResourceTypes
+    }
+
     if (initiatorDomains && initiatorDomains.length > 0) {
         dnrRule.condition.initiatorDomains = initiatorDomains
     }
@@ -175,6 +185,22 @@ function generateDNRRule ({
             dnrRule.condition.excludedInitiatorDomains =
                 excludedInitiatorDomains
         }
+    }
+
+    if (tabIds && tabIds.length > 0) {
+        dnrRule.condition.tabIds = tabIds
+    }
+
+    if (excludedTabIds && excludedTabIds.length > 0) {
+        dnrRule.condition.excludedTabIds = excludedTabIds
+    }
+
+    if (requestMethods && requestMethods.length > 0) {
+        dnrRule.condition.requestMethods = requestMethods
+    }
+
+    if (excludedRequestMethods && excludedRequestMethods.length > 0) {
+        dnrRule.condition.excludedRequestMethods = excludedRequestMethods
     }
 
     return dnrRule

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,85 @@
+const assert = require('assert')
+
+const {
+    generateDNRRule
+} = require('../lib/utils')
+
+describe('generateDNRRule', () => {
+    it('should populate tabIds/excludedTabIds conditions', async () => {
+        {
+            const { condition } = await generateDNRRule({
+                priority: 10,
+                actionType: 'allow',
+                tabIds: [-1, 10]
+            })
+
+            await assert.deepEqual(condition, {
+                tabIds: [-1, 10]
+            })
+        }
+
+        {
+            const { condition } = await generateDNRRule({
+                priority: 10,
+                actionType: 'allow',
+                excludedTabIds: [20, 30]
+            })
+
+            await assert.deepEqual(condition, {
+                excludedTabIds: [20, 30]
+            })
+        }
+    })
+
+    it('should populate requestMethods/excludedRequestMethods conditions', async () => {
+        {
+            const { condition } = await generateDNRRule({
+                priority: 10,
+                actionType: 'allow',
+                requestMethods: ['post', 'get']
+            })
+
+            await assert.deepEqual(condition, {
+                requestMethods: ['post', 'get']
+            })
+        }
+
+        {
+            const { condition } = await generateDNRRule({
+                priority: 10,
+                actionType: 'allow',
+                excludedRequestMethods: ['connect']
+            })
+
+            await assert.deepEqual(condition, {
+                excludedRequestMethods: ['connect']
+            })
+        }
+    })
+
+    it('should populate resourceTypes/excludedResourceTypes conditions', async () => {
+        {
+            const { condition } = await generateDNRRule({
+                priority: 10,
+                actionType: 'allow',
+                resourceTypes: ['main_frame', 'sub_frame']
+            })
+
+            await assert.deepEqual(condition, {
+                resourceTypes: ['main_frame', 'sub_frame']
+            })
+        }
+
+        {
+            const { condition } = await generateDNRRule({
+                priority: 10,
+                actionType: 'allow',
+                excludedResourceTypes: ['script']
+            })
+
+            await assert.deepEqual(condition, {
+                excludedResourceTypes: ['script']
+            })
+        }
+    })
+})


### PR DESCRIPTION
Expand the generateDNRRule helper function to support the tabIds/excludedTabIds, requestMethods/excludedRequestMethods and excludedResourceTypes conditions.