### PR TITLE
HTTP Cookie blocking

### DIFF
--- a/lib/combined.js
+++ b/lib/combined.js
@@ -11,13 +11,13 @@ import { generateCookieBlockingRuleset } from './cookies'
  *   excluded from any contentBlocking/unprotectedTemporary allowlisting rules.
  * @returns {import('./utils').RulesetResult}
  */
-function generateCombinedConfigBlocklistRuleset (tds, config, denylistedDomains) {
+function generateCombinedConfigBlocklistRuleset (tds, config, denylistedDomains, startingRuleId = 1) {
     // Merge cookie feature exceptions with unprotectedTemporary, then remove any denylisted domains
     const cookieAllowlist = (config.features.cookie?.exceptions.map(entry => entry.domain) || [])
         .concat(config.unprotectedTemporary.map(entry => entry.domain))
         .filter(domain => denylistedDomains.includes(domain))
     const excludedCookieDomains = config.features.cookie?.settings.excludedCookieDomains.map(entry => entry.domain)
-    return generateCookieBlockingRuleset(tds, excludedCookieDomains, cookieAllowlist)
+    return generateCookieBlockingRuleset(tds, excludedCookieDomains, cookieAllowlist, startingRuleId)
 }
 
 exports.generateCombinedConfigBlocklistRuleset = generateCombinedConfigBlocklistRuleset

--- a/lib/combined.js
+++ b/lib/combined.js
@@ -1,4 +1,4 @@
-import { generateCookieBlockingRuleset } from './cookies'
+const { generateCookieBlockingRuleset } = require('./cookies')
 
 /**
  * Build blocklist rules which depend on both the privacy configuration and blocklist. This

--- a/lib/combined.js
+++ b/lib/combined.js
@@ -1,0 +1,23 @@
+import { generateCookieBlockingRuleset } from './cookies'
+
+/**
+ * Build blocklist rules which depend on both the privacy configuration and blocklist. This
+ * currently covers:
+ *   - cookie header blocking
+ * @param {import('./utils').TDS} tds The tracker blocklist
+ * @param {import('./utils').PrivacyConfiguration} config Privacy config
+ * @param {string[]} denylistedDomains
+ *   Domains that the user has specifically denylisted. These domains should be
+ *   excluded from any contentBlocking/unprotectedTemporary allowlisting rules.
+ * @returns {import('./utils').RulesetResult}
+ */
+function generateCombinedConfigBlocklistRuleset (tds, config, denylistedDomains) {
+    // Merge cookie feature exceptions with unprotectedTemporary, then remove any denylisted domains
+    const cookieAllowlist = (config.features.cookie?.exceptions.map(entry => entry.domain) || [])
+        .concat(config.unprotectedTemporary.map(entry => entry.domain))
+        .filter(domain => denylistedDomains.includes(domain))
+    const excludedCookieDomains = config.features.cookie?.settings.excludedCookieDomains.map(entry => entry.domain)
+    return generateCookieBlockingRuleset(tds, excludedCookieDomains, cookieAllowlist)
+}
+
+exports.generateCombinedConfigBlocklistRuleset = generateCombinedConfigBlocklistRuleset

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -38,10 +38,10 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
     for (const [trackerDomain, trackerEntry] of Object.entries(tds.trackers)) {
         const mapEntry = entityDomainMapping.get(trackerEntry.owner.name) || { domains: new Set(), trackerDomains: new Set() }
 
-        requestDomainsByTrackerDomain.get(trackerDomain)?.forEach(d => {
-            mapEntry.domains.add(d)
-            mapEntry.trackerDomains.add(d)
-        })
+        for (const domain of requestDomainsByTrackerDomain.get(trackerDomain) || []) {
+            mapEntry.domains.add(domain)
+            mapEntry.trackerDomains.add(domain)
+        }
         tds.entities[trackerEntry.owner.name].domains.forEach(d => mapEntry.domains.add(d))
 
         entityDomainMapping.set(trackerEntry.owner.name, mapEntry)

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -69,7 +69,7 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
                 responseHeaders: [{ header: 'set-cookie', operation: 'remove' }]
             },
             condition: {
-                requestDomains: [...trackerDomains],
+                requestDomains: Array.from(trackerDomains),
                 excludedInitiatorDomains: [...domains, ...siteAllowlist],
                 excludedRequestDomains
             }

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -27,7 +27,8 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
     // collect CNAMEs for each tracker
     const requestDomainsByTrackerDomain = generateRequestDomainsByTrackerDomain(tds)
 
-    // process exclusions: find their tracker domain so we know which rule to put it in
+    // process exclusions: Find the tracker domain associated with each excluded cookie domain,
+    // so that the correct exclusions can be added with each declarativeNetRequest rule.
     for (const domain of excludedCookieDomains) {
         const trackerEntryDomain = getTrackerEntryDomain(tds.trackers, domain)
         storeInLookup(trackerDomainExclusions, trackerEntryDomain, [domain])
@@ -54,6 +55,8 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
                 excludedRequestDomains.push(...trackerDomainExclusions.get(domain) || [])
             }
         }
+        // If this is a single tracker domain entity, put it to the side. We'll generate a single
+        // DNR rule for all of these (see description of `singleDomainEntityDomains` for more)
         if (domains.size === 1 && trackerDomains.size === 1 && excludedRequestDomains.length === 0) {
             singleDomainEntityDomains.push(...domains)
             continue

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,7 +1,7 @@
 const { CEILING_PRIORITY } = require('./trackerAllowlist')
 const { generateTrackerDomainAliasMapping, getTrackerEntryDomain, storeInLookup } = require('./utils')
 
-const COOKIE_PRIORITY = CEILING_PRIORITY + 100;
+const COOKIE_PRIORITY = CEILING_PRIORITY + 100
 
 /**
  * Build HTTP cookie blocking rules from the blocklist and cookie configuration
@@ -29,7 +29,7 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
 
     // process exclusions: find their tracker domain so we know which rule to put it in
     excludedCookieDomains.forEach(d => {
-        const trackerEntryDomain = getTrackerEntryDomain(tds.trackers, d);
+        const trackerEntryDomain = getTrackerEntryDomain(tds.trackers, d)
         storeInLookup(trackerDomainExclusions, trackerEntryDomain, [d])
     })
 

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -11,17 +11,11 @@ const COOKIE_PRIORITY = CEILING_PRIORITY + 100
  * @returns {import('./utils').DNRRule[]} Cookie blocking rules
  */
 function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlist, startingRuleId = 1) {
-    /**
-     * @type {import('./utils').DNRRule[]}
-     */
+    /** @type {import('./utils').DNRRule[]} */
     const rules = []
-    /**
-     * @type {Map<string, { domains: Set<string>, trackerDomains: Set<string> }>}
-     */
+    /** @type {Map<string, { domains: Set<string>, trackerDomains: Set<string> }>} */
     const entityDomainMapping = new Map()
-    /**
-     * @type {Map<string, string[]>}
-     */
+    /** @type {Map<string, string[]>} */
     const trackerDomainExclusions = new Map()
     const singleDomainEntityDomains = []
     // collect CNAMEs for each tracker

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -8,11 +8,11 @@ const COOKIE_PRIORITY = CEILING_PRIORITY + 100
  * @param {import('./utils').TDS} tds The tracker blocklist
  * @param {string[]} excludedCookieDomains 3p domains for which we shouldn't block cookies
  * @param {string[]} siteAllowlist Sites on which we shouldn't block 3p cookies
- * @returns {chrome.declarativeNetRequest.Rule[]} Cookie blocking rules
+ * @returns {import('./utils').DNRRule[]} Cookie blocking rules
  */
 function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlist, startingRuleId = 1) {
     /**
-     * @type {chrome.declarativeNetRequest.Rule[]}
+     * @type {import('./utils').DNRRule[]}
      */
     const rules = []
     /**
@@ -20,7 +20,7 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
      */
     const entityDomainMapping = new Map()
     /**
-     * @type {Map<string, string[]}
+     * @type {Map<string, string[]>}
      */
     const trackerDomainExclusions = new Map()
     const singleDomainEntityDomains = []

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -95,3 +95,4 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
 }
 
 exports.generateCookieBlockingRuleset = generateCookieBlockingRuleset
+exports.COOKIE_PRIORITY = COOKIE_PRIORITY

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -28,10 +28,10 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
     const requestDomainsByTrackerDomain = generateRequestDomainsByTrackerDomain(tds)
 
     // process exclusions: find their tracker domain so we know which rule to put it in
-    excludedCookieDomains.forEach(d => {
-        const trackerEntryDomain = getTrackerEntryDomain(tds.trackers, d)
-        storeInLookup(trackerDomainExclusions, trackerEntryDomain, [d])
-    })
+    for (const domain of excludedCookieDomains) {
+        const trackerEntryDomain = getTrackerEntryDomain(tds.trackers, domain)
+        storeInLookup(trackerDomainExclusions, trackerEntryDomain, [domain])
+    }
 
     // Gather trackers by owner and build the set of owned and owned tracker domains for each
     for (const [trackerDomain, trackerEntry] of Object.entries(tds.trackers)) {
@@ -49,11 +49,11 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
     for (const [, { domains, trackerDomains }] of entityDomainMapping.entries()) {
         // find if domains are excluded for this entity
         const excludedRequestDomains = []
-        trackerDomains.forEach(d => {
-            if (trackerDomainExclusions.has(d)) {
-                excludedRequestDomains.push(...trackerDomainExclusions.get(d) || [])
+        for (const domain of trackerDomains) {
+            if (trackerDomainExclusions.has(domain)) {
+                excludedRequestDomains.push(...trackerDomainExclusions.get(domain) || [])
             }
-        })
+        }
         if (domains.size === 1 && trackerDomains.size === 1 && excludedRequestDomains.length === 0) {
             singleDomainEntityDomains.push(...domains)
             continue

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,7 +1,6 @@
-const { CEILING_PRIORITY } = require('./trackerAllowlist')
 const { generateRequestDomainsByTrackerDomain, getTrackerEntryDomain, storeInLookup } = require('./utils')
 
-const COOKIE_PRIORITY = CEILING_PRIORITY + 100
+const COOKIE_PRIORITY = 40000
 
 /**
  * Build HTTP cookie blocking rules from the blocklist and cookie configuration

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,5 +1,5 @@
 const { CEILING_PRIORITY } = require('./trackerAllowlist')
-const { generateTrackerDomainAliasMapping, getTrackerEntryDomain, storeInLookup } = require('./utils')
+const { generateRequestDomainsByTrackerDomain, getTrackerEntryDomain, storeInLookup } = require('./utils')
 
 const COOKIE_PRIORITY = CEILING_PRIORITY + 100
 
@@ -19,7 +19,7 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
     const trackerDomainExclusions = new Map()
     const singleDomainEntityDomains = []
     // collect CNAMEs for each tracker
-    const requestDomainsByTrackerDomain = generateTrackerDomainAliasMapping(tds)
+    const requestDomainsByTrackerDomain = generateRequestDomainsByTrackerDomain(tds)
 
     // process exclusions: find their tracker domain so we know which rule to put it in
     excludedCookieDomains.forEach(d => {

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -7,7 +7,7 @@ const COOKIE_PRIORITY = 40000
  * @param {import('./utils').TDS} tds The tracker blocklist
  * @param {string[]} excludedCookieDomains 3p domains for which we shouldn't block cookies
  * @param {string[]} siteAllowlist Sites on which we shouldn't block 3p cookies
- * @returns {import('./utils').DNRRule[]} Cookie blocking rules
+ * @returns {import('./utils').RulesetResult} Cookie blocking rules
  */
 function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlist, startingRuleId = 1) {
     /** @type {import('./utils').DNRRule[]} */
@@ -16,6 +16,8 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
     const entityDomainMapping = new Map()
     /** @type {Map<string, string[]>} */
     const trackerDomainExclusions = new Map()
+    /** @type {import('./utils').MatchDetailsByRuleId} */
+    const matchDetailsByRuleId = {}
     /**
      * @type {string[]} tracker domains that are part of entities which only have a single domain
      * associated with them. These domains have a simplified same entity rule, which we can
@@ -74,6 +76,10 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
                 excludedRequestDomains
             }
         })
+        matchDetailsByRuleId[startingRuleId] = {
+            type: 'cookieBlocking',
+            possibleTrackerDomains: Array.from(trackerDomains)
+        }
     }
     // create a single rule for all domains which only have 1 domain
     if (singleDomainEntityDomains.length > 0) {
@@ -91,9 +97,16 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
                 domainType: 'thirdParty'
             }
         })
+        matchDetailsByRuleId[startingRuleId] = {
+            type: 'cookieBlocking',
+            possibleTrackerDomains: singleDomainEntityDomains
+        }
     }
 
-    return rules
+    return {
+        ruleset: rules,
+        matchDetailsByRuleId
+    }
 }
 
 exports.generateCookieBlockingRuleset = generateCookieBlockingRuleset

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -17,6 +17,12 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
     const entityDomainMapping = new Map()
     /** @type {Map<string, string[]>} */
     const trackerDomainExclusions = new Map()
+    /**
+     * @type {string[]} tracker domains that are part of entities which only have a single domain
+     * associated with them. These domains have a simplified same entity rule, which we can
+     * implement with the `domainType: thirdParty` rule condition. This allows us to collapse
+     * all these domains into a single rule.
+     */
     const singleDomainEntityDomains = []
     // collect CNAMEs for each tracker
     const requestDomainsByTrackerDomain = generateRequestDomainsByTrackerDomain(tds)

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -84,7 +84,7 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
     // create a single rule for all domains which only have 1 domain
     if (singleDomainEntityDomains.length > 0) {
         rules.push({
-            id: startingRuleId++,
+            id: ++startingRuleId,
             priority: COOKIE_PRIORITY,
             action: {
                 type: 'modifyHeaders',

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,0 +1,97 @@
+const { CEILING_PRIORITY } = require('./trackerAllowlist')
+const { generateTrackerDomainAliasMapping, getTrackerEntryDomain, storeInLookup } = require('./utils')
+
+const COOKIE_PRIORITY = CEILING_PRIORITY + 100;
+
+/**
+ * Build HTTP cookie blocking rules from the blocklist and cookie configuration
+ * @param {import('./utils').TDS} tds The tracker blocklist
+ * @param {string[]} excludedCookieDomains 3p domains for which we shouldn't block cookies
+ * @param {string[]} siteAllowlist Sites on which we shouldn't block 3p cookies
+ * @returns {chrome.declarativeNetRequest.Rule[]} Cookie blocking rules
+ */
+function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlist, startingRuleId = 1) {
+    /**
+     * @type {chrome.declarativeNetRequest.Rule[]}
+     */
+    const rules = []
+    /**
+     * @type {Map<string, { domains: Set<string>, trackerDomains: Set<string> }>}
+     */
+    const entityDomainMapping = new Map()
+    /**
+     * @type {Map<string, string[]}
+     */
+    const trackerDomainExclusions = new Map()
+    const singleDomainEntityDomains = []
+    // collect CNAMEs for each tracker
+    const requestDomainsByTrackerDomain = generateTrackerDomainAliasMapping(tds)
+
+    // process exclusions: find their tracker domain so we know which rule to put it in
+    excludedCookieDomains.forEach(d => {
+        const trackerEntryDomain = getTrackerEntryDomain(tds.trackers, d);
+        storeInLookup(trackerDomainExclusions, trackerEntryDomain, [d])
+    })
+
+    // Gather trackers by owner and build the set of owned and owned tracker domains for each
+    for (const [trackerDomain, trackerEntry] of Object.entries(tds.trackers)) {
+        const mapEntry = entityDomainMapping.get(trackerEntry.owner.name) || { domains: new Set(), trackerDomains: new Set() }
+
+        requestDomainsByTrackerDomain.get(trackerDomain)?.forEach(d => {
+            mapEntry.domains.add(d)
+            mapEntry.trackerDomains.add(d)
+        })
+        tds.entities[trackerEntry.owner.name].domains.forEach(d => mapEntry.domains.add(d))
+
+        entityDomainMapping.set(trackerEntry.owner.name, mapEntry)
+    }
+
+    for (const [, { domains, trackerDomains }] of entityDomainMapping.entries()) {
+        // find if domains are excluded for this entity
+        const excludedRequestDomains = []
+        trackerDomains.forEach(d => {
+            if (trackerDomainExclusions.has(d)) {
+                excludedRequestDomains.push(...trackerDomainExclusions.get(d) || [])
+            }
+        })
+        if (domains.size === 1 && trackerDomains.size === 1 && excludedRequestDomains.length === 0) {
+            singleDomainEntityDomains.push(...domains)
+            continue
+        }
+        rules.push({
+            id: startingRuleId++,
+            priority: COOKIE_PRIORITY,
+            action: {
+                type: 'modifyHeaders',
+                requestHeaders: [{ header: 'cookie', operation: 'remove' }],
+                responseHeaders: [{ header: 'set-cookie', operation: 'remove' }]
+            },
+            condition: {
+                requestDomains: [...trackerDomains],
+                excludedInitiatorDomains: [...domains, ...siteAllowlist],
+                excludedRequestDomains
+            }
+        })
+    }
+    // create a single rule for all domains which only have 1 domain
+    if (singleDomainEntityDomains.length > 0) {
+        rules.push({
+            id: startingRuleId++,
+            priority: COOKIE_PRIORITY,
+            action: {
+                type: 'modifyHeaders',
+                requestHeaders: [{ header: 'cookie', operation: 'remove' }],
+                responseHeaders: [{ header: 'set-cookie', operation: 'remove' }]
+            },
+            condition: {
+                requestDomains: singleDomainEntityDomains,
+                excludedInitiatorDomains: siteAllowlist,
+                domainType: 'thirdParty'
+            }
+        })
+    }
+
+    return rules
+}
+
+exports.generateCookieBlockingRuleset = generateCookieBlockingRuleset

--- a/lib/extensionConfiguration.js
+++ b/lib/extensionConfiguration.js
@@ -5,14 +5,6 @@ const { generateTemporaryAllowlistRules } = require('./temporaryAllowlist')
 const { generateGPCheaderRules } = require('./gpc')
 
 /**
- * @typedef {object} generateExtensionConfigurationRulesetResult
- * @property {import('./utils.js').DNRRule[]} ruleset
- *   The generated declarativeNetRequest ruleset.
- * @property {object} matchDetailsByRuleId
- *   Rule ID -> match details.
- */
-
-/**
  * Generated an extension configuration declarativeNetRequest ruleset.
  * @param {object} extensionConfig
  *   The extension configuration.
@@ -25,7 +17,7 @@ const { generateGPCheaderRules } = require('./gpc')
  * @param {number} [startingRuleId = 1]
  *   Rule ID for the generated declarativeNetRequest rules to start from. Rule
  *   IDs are incremented sequentially from the starting point.
- * @return {Promise<generateExtensionConfigurationRulesetResult>}
+ * @return {Promise<import('./utils.js').RulesetResult>}
  */
 
 async function generateExtensionConfigurationRuleset (
@@ -37,6 +29,7 @@ async function generateExtensionConfigurationRuleset (
 
     let ruleId = startingRuleId
     const ruleset = []
+    /** @type {import('./utils').MatchDetailsByRuleId} */
     const matchDetailsByRuleId = {}
 
     const appendRuleResult = result => {

--- a/lib/tds.js
+++ b/lib/tds.js
@@ -5,7 +5,8 @@ const {
     getTrackerEntryDomain,
     storeInLookup,
     processRegexTrackerRule,
-    resourceTypes
+    resourceTypes,
+    generateTrackerDomainAliasMapping
 } = require('./utils')
 
 // Priority that the Tracker Blocking declarativeNetRequest rules start from.
@@ -446,54 +447,12 @@ async function generateTdsRuleset (
         throw new Error('Missing isRegexSupported function.')
     }
 
-    const requestDomainsByTrackerDomain = new Map()
+    const requestDomainsByTrackerDomain = generateTrackerDomainAliasMapping(tds)
 
     // Ensure that tracker entries for more specific (longer) domains are
     // matched first, by giving the corresponding declarativeNetRequest rules
     // for longer domains a higher priority.
     const priorityByTrackerDomain = calculateTrackerEntryPriorities(tds)
-
-    // Create a lookup of each tracker entry's domain, that matching cname
-    // entries will be added to.
-    for (const trackerDomain of Object.keys(tds.trackers)) {
-        storeInLookup(
-            requestDomainsByTrackerDomain, trackerDomain, [trackerDomain]
-        )
-    }
-
-    // Handle cname mappings.
-    for (const [domain, cname] of Object.entries(tds.cnames)) {
-        // Find the appropriate tracker entry that the cname entry should apply
-        // to.
-        const trackerEntryDomain = getTrackerEntryDomain(tds.trackers, cname)
-        if (trackerEntryDomain) {
-            // There are some difficult edge-cases when the subdomain of a cname
-            // entry has its own tracker entry. Requests are first checked
-            // against the tracker entry, before the cname entry. Worse still,
-            // if a rule matches the tracker entry and has the action of block,
-            // the request will still be allowed (due to being first-party) even
-            // if there's also a cname entry rule to block the request.
-            // Therefore, for now skip cname mapping if there is a parent
-            // tracker entry.
-            // See https://github.com/duckduckgo/privacy-grade/blob/4d28937/src/classes/trackers.js#L111-L125
-            if (getTrackerEntryDomain(tds.trackers, domain, 1)) {
-                continue
-            }
-
-            // Strictly speaking, the domain should also be added to the
-            // excluded initiator domains for the corresponding tracker entry's
-            // entity. In practice however, this makes no difference and adds
-            // significantly to the ruleset size.
-
-            // Ensure that the cname is added to included request domains for
-            // the matching tracker entry.
-            storeInLookup(
-                requestDomainsByTrackerDomain,
-                trackerEntryDomain,
-                [domain]
-            )
-        }
-    }
 
     // Generate the declarativeNetRequest rules for the tracker entries.
     let regexRuleCount = 0

--- a/lib/tds.js
+++ b/lib/tds.js
@@ -6,7 +6,7 @@ const {
     storeInLookup,
     processRegexTrackerRule,
     resourceTypes,
-    generateTrackerDomainAliasMapping
+    generateRequestDomainsByTrackerDomain
 } = require('./utils')
 
 // Priority that the Tracker Blocking declarativeNetRequest rules start from.
@@ -447,7 +447,7 @@ async function generateTdsRuleset (
         throw new Error('Missing isRegexSupported function.')
     }
 
-    const requestDomainsByTrackerDomain = generateTrackerDomainAliasMapping(tds)
+    const requestDomainsByTrackerDomain = generateRequestDomainsByTrackerDomain(tds)
 
     // Ensure that tracker entries for more specific (longer) domains are
     // matched first, by giving the corresponding declarativeNetRequest rules

--- a/lib/tds.js
+++ b/lib/tds.js
@@ -327,6 +327,7 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
     const ruleIdByByStringifiedDNRRule = new Map()
     const requestDomainsByRuleId = new Map()
     const trackerDomainsByRuleId = new Map()
+    /** @type {import('./utils').MatchDetailsByRuleId} */
     const matchDetailsByRuleId = {}
 
     // Combine similar rules and create the ruleset.
@@ -409,14 +410,6 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
 }
 
 /**
- * @typedef {object} generateTdsRulesetResult
- * @property {import('./utils.js').DNRRule[]} ruleset
- *   The generated Tracker Blocking declarativeNetRequest ruleset.
- * @property {object} matchDetailsByRuleId
- *   Rule ID -> match details.
- */
-
-/**
  * Converts a Tracker Blocking configuration into a declarativeNetRequest
  * ruleset that blocks/redirects requests to known trackers.
  * @param {object} tds
@@ -432,7 +425,7 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
  * @param {number} [startingRuleId = 1]
  *   Rule ID for the generated declarativeNetRequest rules to start from. Rule
  *   IDs are incremented sequentially from the starting point.
- * @return {Promise<generateTdsRulesetResult>}
+ * @return {Promise<import('./utils').RulesetResult>}
  */
 async function generateTdsRuleset (
     tds, supportedSurrogateScripts, surrogatePathPrefix, isRegexSupported,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,48 @@
  */
 
 /**
+ * @typedef {{
+ *   domain: string;
+ *   reason: string
+ * }} PrivacyConfigDomainEntry
+ */
+/**
+ * @typedef {object} PrivacyConfigFeature
+ * @property {string} state
+ * @property {string | undefined} minSupportedVersion
+ * @property {string} hash
+ * @property {S} settings
+ * @property {PrivacyConfigDomainEntry[]} exceptions
+ * @template S
+ */
+/**
+ * @typedef {object} PrivacyConfiguration
+ * @property {PrivacyConfigDomainEntry[]} unprotectedTemporary
+ * @property {{
+ *  cookie: PrivacyConfigFeature<{
+ *      trackerCookie: string;
+ *      nonTrackerCookie: string;
+ *      excludedCookieDomains: PrivacyConfigDomainEntry[];
+ *  }>
+ * }} features
+ */
+/**
+ * @typedef {{[ruleId: number]: {
+ *   type: string;
+ *   possibleTrackerDomains?: string[];
+ *   domain?: string;
+ *   reason?: string;
+ * }}} MatchDetailsByRuleId
+*/
+/**
+ * @typedef RulesetResult
+ * @property {import('./utils.js').DNRRule[]} ruleset
+ *   The generated Tracker Blocking declarativeNetRequest ruleset.
+ * @property {MatchDetailsByRuleId} matchDetailsByRuleId
+ *   Rule ID -> match details.
+ */
+
+/**
  * Unfortunately it's a little tricky to interact with TypeScript Enum types
  * from JavaScript code, assigning the literal value (even if valid) results in
  * a type coercion error. As a workaround, use the backtick syntax to get the

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -470,11 +470,11 @@ function getTrackerEntryDomain (trackerEntries, domain, skipSubdomains = 0) {
 }
 
 /**
- * Generate a mapping from tracker domain to a list of related aliases (via CNAME)
+ * Generate a mapping from tracker domain to a list of related aliases (via CNAME) as well as itself
  * @param {TDS} tds Tracker blocklist
  * @returns {Map<string, string[]>} domain mapping
  */
-function generateTrackerDomainAliasMapping (tds) {
+function generateRequestDomainsByTrackerDomain (tds) {
     const requestDomainsByTrackerDomain = new Map()
     // Create a lookup of each tracker entry's domain, that matching cname
     // entries will be added to.
@@ -531,4 +531,4 @@ exports.generateDNRRule = generateDNRRule
 exports.processRegexTrackerRule = processRegexTrackerRule
 exports.processPlaintextTrackerRule = processPlaintextTrackerRule
 exports.getTrackerEntryDomain = getTrackerEntryDomain
-exports.generateTrackerDomainAliasMapping = generateTrackerDomainAliasMapping
+exports.generateRequestDomainsByTrackerDomain = generateRequestDomainsByTrackerDomain

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,17 @@
 /** @module utils */
 
 /**
- *  @typedef {import('../node_modules/@duckduckgo/privacy-grade/src/classes/trackers.js').TrackerObj} TrackerObj
+ * @typedef {import('../node_modules/@duckduckgo/privacy-grade/src/classes/trackers.js').TrackerObj} TrackerObj
+ * @typedef {{
+ *  domains: string[];
+ *  prevalence: number;
+ *  displayName: string;
+ * }} Entity
+ * @typedef {{
+ *  trackers: Record<string, TrackerObj>;
+ *  entities: Record<string, Entity>;
+ *  cnames: Record<string, string>;
+ * }} TDS
  */
 
 /**
@@ -459,6 +469,55 @@ function getTrackerEntryDomain (trackerEntries, domain, skipSubdomains = 0) {
     return null
 }
 
+/**
+ * Generate a mapping from tracker domain to a list of related aliases (via CNAME)
+ * @param {TDS} tds Tracker blocklist
+ * @returns {Map<string, string[]>} domain mapping
+ */
+function generateTrackerDomainAliasMapping (tds) {
+    const requestDomainsByTrackerDomain = new Map()
+    // Create a lookup of each tracker entry's domain, that matching cname
+    // entries will be added to.
+    for (const trackerDomain of Object.keys(tds.trackers)) {
+        storeInLookup(
+            requestDomainsByTrackerDomain, trackerDomain, [trackerDomain]
+        )
+    }
+    for (const [domain, cname] of Object.entries(tds.cnames)) {
+        // Find the appropriate tracker entry that the cname entry should apply
+        // to.
+        const trackerEntryDomain = getTrackerEntryDomain(tds.trackers, cname)
+        if (trackerEntryDomain) {
+            // There are some difficult edge-cases when the subdomain of a cname
+            // entry has its own tracker entry. Requests are first checked
+            // against the tracker entry, before the cname entry. Worse still,
+            // if a rule matches the tracker entry and has the action of block,
+            // the request will still be allowed (due to being first-party) even
+            // if there's also a cname entry rule to block the request.
+            // Therefore, for now skip cname mapping if there is a parent
+            // tracker entry.
+            // See https://github.com/duckduckgo/privacy-grade/blob/4d28937/src/classes/trackers.js#L111-L125
+            if (getTrackerEntryDomain(tds.trackers, domain, 1)) {
+                continue
+            }
+
+            // Strictly speaking, the domain should also be added to the
+            // excluded initiator domains for the corresponding tracker entry's
+            // entity. In practice however, this makes no difference and adds
+            // significantly to the ruleset size.
+
+            // Ensure that the cname is added to included request domains for
+            // the matching tracker entry.
+            storeInLookup(
+                requestDomainsByTrackerDomain,
+                trackerEntryDomain,
+                [domain]
+            )
+        }
+    }
+    return requestDomainsByTrackerDomain
+}
+
 /** @type Set<ResourceType> */
 const resourceTypes = new Set([
     'main_frame', 'sub_frame', 'stylesheet', 'script', 'image', 'font',
@@ -472,3 +531,4 @@ exports.generateDNRRule = generateDNRRule
 exports.processRegexTrackerRule = processRegexTrackerRule
 exports.processPlaintextTrackerRule = processPlaintextTrackerRule
 exports.getTrackerEntryDomain = getTrackerEntryDomain
+exports.generateTrackerDomainAliasMapping = generateTrackerDomainAliasMapping

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -1,11 +1,148 @@
 const assert = require('assert')
 const { CEILING_PRIORITY } = require('../lib/trackerAllowlist')
 const { CEILING_PRIORITY: TDS_CEILING_PRIORITY } = require('../lib/tds')
-const { COOKIE_PRIORITY } = require('../lib/cookies')
+const { COOKIE_PRIORITY, generateCookieBlockingRuleset } = require('../lib/cookies')
+
+/** @type {import('../lib/utils.js').TDS} */
+const mockTds = {
+    trackers: {
+        'tracker.com': {
+            domain: 'tracker.com',
+            owner: {
+                name: 'TRACKER INC.',
+                displayName: ''
+            },
+            default: 'block',
+            cookies: 0,
+            fingerprinting: 0,
+            prevalence: 0.1,
+            categories: [],
+            rules: []
+        },
+        'track-the-things.com': {
+            domain: 'track-the-things.com',
+            owner: {
+                name: 'MultiTracker Inc.',
+                displayName: ''
+            },
+            default: 'block',
+            cookies: 0,
+            fingerprinting: 0,
+            prevalence: 0.1,
+            categories: [],
+            rules: []
+        },
+        'track-more.com': {
+            domain: 'track-more.com',
+            owner: {
+                name: 'MultiTracker Inc.',
+                displayName: ''
+            },
+            default: 'block',
+            cookies: 0,
+            fingerprinting: 0,
+            prevalence: 0.1,
+            categories: [],
+            rules: []
+        },
+        'sub.example.com': {
+            domain: 'sub.example.com',
+            owner: {
+                name: 'Example.com',
+                displayName: ''
+            },
+            default: 'block',
+            cookies: 0,
+            fingerprinting: 0,
+            prevalence: 0.1,
+            categories: [],
+            rules: []
+        }
+    },
+    entities: {
+        'TRACKER INC.': {
+            domains: [
+                'tracker.com'
+            ],
+            prevalence: 0,
+            displayName: ''
+        },
+        'MultiTracker Inc.': {
+            domains: [
+                'track-the-things.com',
+                'track-more.com',
+                'track-homepage.com'
+            ],
+            prevalence: 0,
+            displayName: ''
+        },
+        'Example.com': {
+            domains: [
+                'example.com'
+            ],
+            prevalence: 0,
+            displayName: ''
+        }
+    },
+    cnames: {
+        'track.example.com': 'example.track-the-things.com'
+    }
+}
 
 describe('cookie rules', () => {
     it('have higher priority than tracker allowlist rules', () => {
         assert.ok(COOKIE_PRIORITY > CEILING_PRIORITY)
         assert.ok(COOKIE_PRIORITY > TDS_CEILING_PRIORITY)
+    })
+
+    describe('generateCookieBlockingRuleset', () => {
+        it('empty tds generates 0 rules', () => {
+            const rules = generateCookieBlockingRuleset({
+                trackers: {},
+                entities: {},
+                cnames: {}
+            }, [], [])
+            assert.equal(rules.length, 0)
+        })
+
+        it('generates a block rule with entity domains included (including CNAMEs)', () => {
+            const rules = generateCookieBlockingRuleset(mockTds, [], [])
+            const trackerRule = rules.find(rule => rule.condition.requestDomains?.includes('track-the-things.com'))
+            assert.ok(!!trackerRule)
+            assert.deepEqual(trackerRule.condition.requestDomains, ['track-the-things.com', 'track.example.com', 'track-more.com'])
+            assert.deepEqual(trackerRule.condition.excludedInitiatorDomains, ['track-the-things.com', 'track.example.com', 'track-more.com', 'track-homepage.com'])
+        })
+
+        it('excludedCookieDomains: removes a domain from the rules', () => {
+            const rules = generateCookieBlockingRuleset(mockTds, ['broken.track-more.com'], [])
+            const trackerRule = rules.find(rule => rule.condition.requestDomains?.includes('track-the-things.com'))
+            assert.ok(!!trackerRule)
+            assert.deepEqual(trackerRule.condition.requestDomains, ['track-the-things.com', 'track.example.com', 'track-more.com'])
+            assert.deepEqual(trackerRule.condition.excludedInitiatorDomains, ['track-the-things.com', 'track.example.com', 'track-more.com', 'track-homepage.com'])
+            assert.deepEqual(trackerRule.condition.excludedRequestDomains, ['broken.track-more.com'])
+            // check that this exclusion isn't added to irrelevant rules
+            const otherRule = rules.find(rule => rule.condition.requestDomains?.includes('tracker.com'))
+            assert.deepEqual(otherRule?.condition.excludedRequestDomains || [], [])
+        })
+
+        it('site allowlist domains are added to every rule', () => {
+            const rules = generateCookieBlockingRuleset(mockTds, [], ['safe.site'])
+            assert.ok(rules.every(r => r.condition.excludedInitiatorDomains?.includes('safe.site')))
+        })
+
+        it('groups single domain entities', () => {
+            const rules = generateCookieBlockingRuleset(mockTds, [], [])
+            const thirdPartyRules = rules.filter(r => r.condition.domainType === 'thirdParty')
+            assert.equal(thirdPartyRules.length, 1)
+            assert.deepEqual(thirdPartyRules[0].condition.requestDomains, ['tracker.com'])
+        })
+
+        it('handles not eTLD+1 trackers', () => {
+            const rules = generateCookieBlockingRuleset(mockTds, [], [])
+            const exampleRule = rules.find(r => r.condition.requestDomains?.includes('sub.example.com'))
+            assert.ok(!!exampleRule)
+            assert.deepEqual(exampleRule.condition.requestDomains, ['sub.example.com'])
+            assert.deepEqual(exampleRule.condition.excludedInitiatorDomains, ['sub.example.com', 'example.com'])
+        })
     })
 })

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -1,7 +1,5 @@
 const assert = require('assert')
-const { CEILING_PRIORITY } = require('../lib/trackerAllowlist')
-const { CEILING_PRIORITY: TDS_CEILING_PRIORITY } = require('../lib/tds')
-const { COOKIE_PRIORITY, generateCookieBlockingRuleset } = require('../lib/cookies')
+const { generateCookieBlockingRuleset } = require('../lib/cookies.js')
 
 /** @type {import('../lib/utils.js').TDS} */
 const mockTds = {

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -97,49 +97,49 @@ describe('cookie rules', () => {
 
     describe('generateCookieBlockingRuleset', () => {
         it('empty tds generates 0 rules', () => {
-            const rules = generateCookieBlockingRuleset({
+            const { ruleset } = generateCookieBlockingRuleset({
                 trackers: {},
                 entities: {},
                 cnames: {}
             }, [], [])
-            assert.equal(rules.length, 0)
+            assert.equal(ruleset.length, 0)
         })
 
         it('generates a block rule with entity domains included (including CNAMEs)', () => {
-            const rules = generateCookieBlockingRuleset(mockTds, [], [])
-            const trackerRule = rules.find(rule => rule.condition.requestDomains?.includes('track-the-things.com'))
+            const { ruleset } = generateCookieBlockingRuleset(mockTds, [], [])
+            const trackerRule = ruleset.find(rule => rule.condition.requestDomains?.includes('track-the-things.com'))
             assert.ok(!!trackerRule)
             assert.deepEqual(trackerRule.condition.requestDomains, ['track-the-things.com', 'track.example.com', 'track-more.com'])
             assert.deepEqual(trackerRule.condition.excludedInitiatorDomains, ['track-the-things.com', 'track.example.com', 'track-more.com', 'track-homepage.com'])
         })
 
         it('excludedCookieDomains: removes a domain from the rules', () => {
-            const rules = generateCookieBlockingRuleset(mockTds, ['broken.track-more.com'], [])
-            const trackerRule = rules.find(rule => rule.condition.requestDomains?.includes('track-the-things.com'))
+            const { ruleset } = generateCookieBlockingRuleset(mockTds, ['broken.track-more.com'], [])
+            const trackerRule = ruleset.find(rule => rule.condition.requestDomains?.includes('track-the-things.com'))
             assert.ok(!!trackerRule)
             assert.deepEqual(trackerRule.condition.requestDomains, ['track-the-things.com', 'track.example.com', 'track-more.com'])
             assert.deepEqual(trackerRule.condition.excludedInitiatorDomains, ['track-the-things.com', 'track.example.com', 'track-more.com', 'track-homepage.com'])
             assert.deepEqual(trackerRule.condition.excludedRequestDomains, ['broken.track-more.com'])
             // check that this exclusion isn't added to irrelevant rules
-            const otherRule = rules.find(rule => rule.condition.requestDomains?.includes('tracker.com'))
+            const otherRule = ruleset.find(rule => rule.condition.requestDomains?.includes('tracker.com'))
             assert.deepEqual(otherRule?.condition.excludedRequestDomains || [], [])
         })
 
         it('site allowlist domains are added to every rule', () => {
-            const rules = generateCookieBlockingRuleset(mockTds, [], ['safe.site'])
-            assert.ok(rules.every(r => r.condition.excludedInitiatorDomains?.includes('safe.site')))
+            const { ruleset } = generateCookieBlockingRuleset(mockTds, [], ['safe.site'])
+            assert.ok(ruleset.every(r => r.condition.excludedInitiatorDomains?.includes('safe.site')))
         })
 
         it('groups single domain entities', () => {
-            const rules = generateCookieBlockingRuleset(mockTds, [], [])
-            const thirdPartyRules = rules.filter(r => r.condition.domainType === 'thirdParty')
+            const { ruleset } = generateCookieBlockingRuleset(mockTds, [], [])
+            const thirdPartyRules = ruleset.filter(r => r.condition.domainType === 'thirdParty')
             assert.equal(thirdPartyRules.length, 1)
             assert.deepEqual(thirdPartyRules[0].condition.requestDomains, ['tracker.com'])
         })
 
         it('handles not eTLD+1 trackers', () => {
-            const rules = generateCookieBlockingRuleset(mockTds, [], [])
-            const exampleRule = rules.find(r => r.condition.requestDomains?.includes('sub.example.com'))
+            const { ruleset } = generateCookieBlockingRuleset(mockTds, [], [])
+            const exampleRule = ruleset.find(r => r.condition.requestDomains?.includes('sub.example.com'))
             assert.ok(!!exampleRule)
             assert.deepEqual(exampleRule.condition.requestDomains, ['sub.example.com'])
             assert.deepEqual(exampleRule.condition.excludedInitiatorDomains, ['sub.example.com', 'example.com'])

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -145,4 +145,19 @@ describe('cookie rules', () => {
             assert.deepEqual(exampleRule.condition.excludedInitiatorDomains, ['sub.example.com', 'example.com'])
         })
     })
+
+    describe('matchDetailsByRuleId', function () {
+        it('returns a list of possible domains for a matched rule', async function () {
+            const { ruleset, matchDetailsByRuleId } = generateCookieBlockingRuleset(mockTds, [], [])
+            await this.browser.addRules(ruleset)
+            const matchedRules = await this.browser.testMatchOutcome({
+                url: 'https://tracker.com/pixel',
+                initiator: 'https://www.example.com/',
+                type: 'xmlhttprequest',
+                tabId: 1
+            })
+            assert.equal(matchedRules.length, 1)
+            assert.ok(matchDetailsByRuleId[matchedRules[0].id].possibleTrackerDomains?.includes('tracker.com'))
+        })
+    })
 })

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -90,11 +90,6 @@ const mockTds = {
 }
 
 describe('cookie rules', () => {
-    it('have higher priority than tracker allowlist rules', () => {
-        assert.ok(COOKIE_PRIORITY > CEILING_PRIORITY)
-        assert.ok(COOKIE_PRIORITY > TDS_CEILING_PRIORITY)
-    })
-
     describe('generateCookieBlockingRuleset', () => {
         it('empty tds generates 0 rules', () => {
             const { ruleset } = generateCookieBlockingRuleset({

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -1,0 +1,11 @@
+const assert = require('assert')
+const { CEILING_PRIORITY } = require('../lib/trackerAllowlist')
+const { CEILING_PRIORITY: TDS_CEILING_PRIORITY } = require('../lib/tds')
+const { COOKIE_PRIORITY } = require('../lib/cookies')
+
+describe('cookie rules', () => {
+    it('have higher priority than tracker allowlist rules', () => {
+        assert.ok(COOKIE_PRIORITY > CEILING_PRIORITY)
+        assert.ok(COOKIE_PRIORITY > TDS_CEILING_PRIORITY)
+    })
+})

--- a/test/referenceTests.js
+++ b/test/referenceTests.js
@@ -160,7 +160,7 @@ describe('Reference Tests', () => {
             const siteAllowlist = config.features.trackingCookies3p.exceptions.map(e => e.domain)
             const unprotectedTemporary = config.unprotectedTemporary.map(e => e.domain)
 
-            cookieRules = generateCookieBlockingRuleset(tds, excludedCookieDomains, [...siteAllowlist, ...unprotectedTemporary], 1000)
+            cookieRules = generateCookieBlockingRuleset(tds, excludedCookieDomains, [...siteAllowlist, ...unprotectedTemporary], 1000).ruleset
         })
 
         this.beforeEach(async function () {

--- a/test/referenceTests.js
+++ b/test/referenceTests.js
@@ -8,12 +8,20 @@ const {
 const {
     generateTdsRuleset
 } = require('../lib/tds')
+const { generateCookieBlockingRuleset } = require('../lib/cookies')
 
 function referenceTestPath (...args) {
     return path.join(
         __dirname, '..', 'node_modules', '@duckduckgo/privacy-reference-tests',
         ...args
     )
+}
+
+function loadJSONFile (prefix, file) {
+    return JSON.parse(fs.readFileSync(
+        path.join(prefix, file),
+        { encoding: 'utf8', flag: 'r' }
+    ))
 }
 
 function* testCases (referenceTests) {
@@ -142,6 +150,57 @@ describe('Reference Tests', () => {
             assert.equal(
                 actualUpgrade, expectedUpgrade, testDescription
             )
+        }
+    })
+
+    describe('cookie blocking', async function () {
+        const referenceTestsPath = referenceTestPath(
+            'block-third-party-tracking-cookies'
+        )
+        const referenceTests = loadJSONFile(referenceTestsPath, 'tests.json')
+        let cookieRules = []
+
+        this.beforeAll(async function () {
+            const tds = loadJSONFile(referenceTestsPath, 'tracker_radar_reference.json')
+            const config = loadJSONFile(referenceTestsPath, 'config_reference.json')
+
+            // TODO: legacy feature name in test config. Should be changed to 'cookies'
+            const excludedCookieDomains = config.features.trackingCookies3p.settings.excludedCookieDomains.map(e => e.domain)
+            const siteAllowlist = config.features.trackingCookies3p.exceptions.map(e => e.domain)
+            const unprotectedTemporary = config.unprotectedTemporary.map(e => e.domain)
+
+            cookieRules = generateCookieBlockingRuleset(tds, excludedCookieDomains, [...siteAllowlist, ...unprotectedTemporary], 1000)
+        })
+
+        this.beforeEach(async function () {
+            await this.browser.addRules(cookieRules)
+        })
+
+        for (const {
+            testDescription, requestURL: initialUrl,
+            siteURL: initiatorUrl, expectCookieHeadersRemoved,
+            expectSetCookieHeadersRemoved
+        } of testCases(referenceTests)) {
+            // exclude document.cookie specs (DNR only does header cookies)
+            if (!testDescription.startsWith('document.cookie')) {
+                it(testDescription, async function () {
+                    const actualMatchedRules = await this.browser.testMatchOutcome({
+                        url: initialUrl,
+                        initiator: initiatorUrl,
+                        type: 'xmlhttprequest',
+                        tabId: 1
+                    })
+                    if (expectCookieHeadersRemoved || expectSetCookieHeadersRemoved) {
+                        assert.equal(actualMatchedRules.length, 1)
+                        const firstMatch = actualMatchedRules[0]
+                        assert.equal(firstMatch.action.type, 'modifyHeaders')
+                        assert.equal(firstMatch.action.requestHeaders[0].header, 'cookie')
+                        assert.equal(firstMatch.action.responseHeaders[0].header, 'set-cookie')
+                    } else {
+                        assert.equal(actualMatchedRules.length, 0)
+                    }
+                })
+            }
         }
     })
 })

--- a/test/referenceTests.js
+++ b/test/referenceTests.js
@@ -46,15 +46,9 @@ describe('Reference Tests', () => {
             'tracker-radar-tests', 'TR-domain-matching'
         )
 
-        const blockList = JSON.parse(fs.readFileSync(
-            path.join(referenceTestsPath, 'tracker_radar_reference.json'),
-            { encoding: 'utf8', flag: 'r' }
-        ))
+        const blockList = loadJSONFile(referenceTestsPath, 'tracker_radar_reference.json')
 
-        const referenceTests = JSON.parse(fs.readFileSync(
-            path.join(referenceTestsPath, 'domain_matching_tests.json'),
-            { encoding: 'utf8', flag: 'r' }
-        ))
+        const referenceTests = loadJSONFile(referenceTestsPath, 'domain_matching_tests.json')
 
         // Note - This should be taken from surrogates.txt, not hardcoded.
         const supportedSurrogateScripts = new Set(['tracker', 'script.js'])
@@ -114,10 +108,7 @@ describe('Reference Tests', () => {
             { encoding: 'utf8', flag: 'r' }
         ).split('\n')
 
-        const referenceTests = JSON.parse(fs.readFileSync(
-            path.join(referenceTestsPath, 'tests.json'),
-            { encoding: 'utf8', flag: 'r' }
-        ))
+        const referenceTests = loadJSONFile(referenceTestsPath, 'tests.json')
 
         await this.browser.addRules(generateSmarterEncryptionRuleset(domains))
 

--- a/test/rulePriorities.js
+++ b/test/rulePriorities.js
@@ -47,11 +47,11 @@ describe('Rule Priorities', () => {
         assert.equal(CONTENT_BLOCKING_ALLOWLIST_PRIORITY, 30000)
         assert.equal(GPC_HEADER_PRIORITY, 40000)
         assert.equal(TRACKING_PARAM_PRIORITY, 40000)
+        assert.equal(COOKIE_PRIORITY, 40000)
         assert.equal(SMARTER_ENCRYPTION_PRIORITY, 100000)
         assert.equal(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY, 1000000)
         assert.equal(SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY, 1000000)
         assert.equal(USER_ALLOWLISTED_PRIORITY, 1000000)
-        assert.equal(COOKIE_PRIORITY, 40000)
     })
 
     it('should have the correct relative rule priorities', () => {

--- a/test/rulePriorities.js
+++ b/test/rulePriorities.js
@@ -18,6 +18,10 @@ const {
 } = require('../lib/tds')
 
 const {
+    COOKIE_PRIORITY
+} = require('../lib/cookies')
+
+const {
     BASELINE_PRIORITY: TRACKER_ALLOWLIST_BASELINE_PRIORITY,
     CEILING_PRIORITY: TRACKER_ALLOWLIST_CEILING_PRIORITY
 } = require('../lib/trackerAllowlist')
@@ -47,6 +51,7 @@ describe('Rule Priorities', () => {
         assert.equal(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY, 1000000)
         assert.equal(SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY, 1000000)
         assert.equal(USER_ALLOWLISTED_PRIORITY, 1000000)
+        assert.equal(COOKIE_PRIORITY, 40000)
     })
 
     it('should have the correct relative rule priorities', () => {
@@ -116,5 +121,9 @@ describe('Rule Priorities', () => {
         assert.ok(USER_ALLOWLISTED_PRIORITY > GPC_HEADER_PRIORITY)
         assert.ok(USER_ALLOWLISTED_PRIORITY > TRACKING_PARAM_PRIORITY)
         assert.ok(USER_ALLOWLISTED_PRIORITY > SMARTER_ENCRYPTION_PRIORITY)
+
+        // Cookie blocking should have higher priority than tracker allowlist
+        // rules, so the allowlist rules do not prevent cookie blocking.
+        assert.ok(COOKIE_PRIORITY > TRACKER_ALLOWLIST_CEILING_PRIORITY)
     })
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,7 +1,8 @@
 const assert = require('assert')
 
 const {
-    generateDNRRule
+    generateDNRRule,
+    generateRequestDomainsByTrackerDomain
 } = require('../lib/utils')
 
 describe('generateDNRRule', () => {
@@ -498,5 +499,35 @@ describe('generateDNRRule', () => {
                 excludedRequestMethods: ['connect']
             })
         }
+    })
+})
+
+describe('generateRequestDomainsByTrackerDomain', () => {
+    it('collects CNAMEs for a domain together with the tracker', () => {
+        const mapping = generateRequestDomainsByTrackerDomain({
+            trackers: {
+                'tracker.com': {
+                    domain: 'tracker.com',
+                    default: 'block',
+                    prevalence: 0,
+                    rules: [],
+                    owner: {
+                        name: '',
+                        displayName: ''
+                    },
+                    cookies: 0,
+                    fingerprinting: 0,
+                    categories: []
+                }
+            },
+            cnames: {
+                'a.example.com': 'sub.tracker.com',
+                'b.example.com': 'sub.other.com'
+            },
+            entities: {}
+        })
+        assert.ok(mapping.has('tracker.com'))
+        assert.deepEqual(mapping.get('tracker.com'), ['tracker.com', 'a.example.com'])
+        assert.ok(!mapping.has('example.com'))
     })
 })


### PR DESCRIPTION
- Add method for generating dynamic modifyHeader rules, given a blocklist and 1st and 3rd party exception domains.
- Includes reference tests for cookie header blocking