### PR TITLE
Rethink some relative rule priorities and expand the tests

### DIFF
--- a/lib/gpc.js
+++ b/lib/gpc.js
@@ -4,7 +4,7 @@ const {
     generateDNRRule
 } = require('./utils')
 
-const GPC_HEADER_PRIORITY = 20000
+const GPC_HEADER_PRIORITY = 40000
 
 function generateGPCheaderRules (config) {
     if (config.features?.gpc?.state !== 'enabled') {

--- a/lib/rulePriorities.js
+++ b/lib/rulePriorities.js
@@ -4,6 +4,6 @@
 //       ddg2dnr respective modules. Rule priorities are only added here when
 //       there is not a better place to put them.
 
-exports.AD_ATTRIBUTION_POLICY_PRIORITY = 20000
+exports.AD_ATTRIBUTION_POLICY_PRIORITY = 30000
 exports.SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY = 1000000
 exports.USER_ALLOWLISTED_PRIORITY = 1000000

--- a/lib/temporaryAllowlist.js
+++ b/lib/temporaryAllowlist.js
@@ -1,7 +1,7 @@
 /** @module temporaryAllowlist */
 
 // The contentBlocking allowlist only disables tracker blocking for a website.
-const CONTENT_BLOCKING_ALLOWLIST_PRIORITY = 20000
+const CONTENT_BLOCKING_ALLOWLIST_PRIORITY = 30000
 // The unprotectedTemporary allowlist disables all protections for a website.
 const UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY = 1000000
 

--- a/test/rulePriorities.js
+++ b/test/rulePriorities.js
@@ -34,60 +34,87 @@ const {
 } = require('../lib/rulePriorities')
 
 describe('Rule Priorities', () => {
-    it('correct relative rule priorities', () => {
-        assert.ok(GPC_HEADER_PRIORITY >
-                  TRACKER_BLOCKING_CEILING_PRIORITY)
+    it('should have an up to date overview of all rule priorities', () => {
+        assert.equal(TRACKER_BLOCKING_BASELINE_PRIORITY, 10000)
+        assert.equal(TRACKER_BLOCKING_CEILING_PRIORITY, 19999)
+        assert.equal(TRACKER_ALLOWLIST_BASELINE_PRIORITY, 20000)
+        assert.equal(TRACKER_ALLOWLIST_CEILING_PRIORITY, 20100)
+        assert.equal(AD_ATTRIBUTION_POLICY_PRIORITY, 30000)
+        assert.equal(CONTENT_BLOCKING_ALLOWLIST_PRIORITY, 30000)
+        assert.equal(GPC_HEADER_PRIORITY, 40000)
+        assert.equal(TRACKING_PARAM_PRIORITY, 40000)
+        assert.equal(SMARTER_ENCRYPTION_PRIORITY, 100000)
+        assert.equal(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY, 1000000)
+        assert.equal(SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY, 1000000)
+        assert.equal(USER_ALLOWLISTED_PRIORITY, 1000000)
+    })
 
-        // Tracker Blocking priorities.
-        assert.ok(TRACKER_BLOCKING_BASELINE_PRIORITY > 0)
-        assert.ok(TRACKER_BLOCKING_CEILING_PRIORITY >
-                  TRACKER_BLOCKING_BASELINE_PRIORITY)
+    it('should have the correct relative rule priorities', () => {
+        // Ceiling priorities should always be higher than baseline.
+        assert.ok(TRACKER_BLOCKING_BASELINE_PRIORITY < TRACKER_BLOCKING_CEILING_PRIORITY)
+        assert.ok(TRACKER_ALLOWLIST_BASELINE_PRIORITY < TRACKER_ALLOWLIST_CEILING_PRIORITY)
 
-        // Tracker Allowlist priorities.
-        assert.ok(TRACKER_ALLOWLIST_BASELINE_PRIORITY >
-                  TRACKER_BLOCKING_CEILING_PRIORITY)
+        // Tracker allowlist should take priority over tracker blocking, but not
+        // other features/allowlists.
+        assert.ok(TRACKER_ALLOWLIST_BASELINE_PRIORITY > TRACKER_BLOCKING_CEILING_PRIORITY)
+        assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < AD_ATTRIBUTION_POLICY_PRIORITY)
+        assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < CONTENT_BLOCKING_ALLOWLIST_PRIORITY)
+        assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < GPC_HEADER_PRIORITY)
+        assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < TRACKING_PARAM_PRIORITY)
+        assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < SMARTER_ENCRYPTION_PRIORITY)
+        assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY)
+        assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY)
+        assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < USER_ALLOWLISTED_PRIORITY)
 
-        assert.ok(TRACKER_ALLOWLIST_BASELINE_PRIORITY <
-                  TRACKING_PARAM_PRIORITY)
+        // Ad attribution allowlisting and the contentBlocking allowlist should
+        // take priority over tracker blocking and the tracker allowlist, but
+        // not other features/allowlists.
+        assert.equal(AD_ATTRIBUTION_POLICY_PRIORITY, CONTENT_BLOCKING_ALLOWLIST_PRIORITY)
+        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY > TRACKER_BLOCKING_CEILING_PRIORITY)
+        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY > TRACKER_ALLOWLIST_CEILING_PRIORITY)
+        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY < GPC_HEADER_PRIORITY)
+        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY < TRACKING_PARAM_PRIORITY)
+        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY < SMARTER_ENCRYPTION_PRIORITY)
+        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY < UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY)
+        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY < SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY)
+        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY < USER_ALLOWLISTED_PRIORITY)
 
-        // Content Blocking allowlist and ad attribution allowlisting rules
-        // should disable Tracker Blocking, but not other protections.
-        assert.ok(CONTENT_BLOCKING_ALLOWLIST_PRIORITY >
-                  TRACKER_BLOCKING_CEILING_PRIORITY)
-        assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY ===
-                  CONTENT_BLOCKING_ALLOWLIST_PRIORITY)
+        // Tracking parameter protection and GPC should take priority over
+        // tracker blocking, the tracker allowlist and the contentBlocking
+        // allowlist, but not over the other features/allowlists.
+        assert.equal(TRACKING_PARAM_PRIORITY, GPC_HEADER_PRIORITY)
+        assert.ok(TRACKING_PARAM_PRIORITY > TRACKER_BLOCKING_CEILING_PRIORITY)
+        assert.ok(TRACKING_PARAM_PRIORITY > TRACKER_ALLOWLIST_CEILING_PRIORITY)
+        assert.ok(TRACKING_PARAM_PRIORITY > CONTENT_BLOCKING_ALLOWLIST_PRIORITY)
+        assert.ok(TRACKING_PARAM_PRIORITY < SMARTER_ENCRYPTION_PRIORITY)
+        assert.ok(TRACKING_PARAM_PRIORITY < UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY)
+        assert.ok(TRACKING_PARAM_PRIORITY < SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY)
+        assert.ok(TRACKING_PARAM_PRIORITY < USER_ALLOWLISTED_PRIORITY)
 
-        assert.ok(TRACKING_PARAM_PRIORITY >
-                  TRACKER_BLOCKING_CEILING_PRIORITY)
+        // Smarter encryption should take priority over most features and
+        // allowlists, except for the unprotectedTemporary allowlist, the
+        // exception for ServiceWorker initiated requests and user allowlisting.
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY > TRACKER_BLOCKING_CEILING_PRIORITY)
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY > TRACKER_ALLOWLIST_CEILING_PRIORITY)
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY > AD_ATTRIBUTION_POLICY_PRIORITY)
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY > CONTENT_BLOCKING_ALLOWLIST_PRIORITY)
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY > GPC_HEADER_PRIORITY)
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY > TRACKING_PARAM_PRIORITY)
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY < UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY)
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY < SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY)
+        assert.ok(SMARTER_ENCRYPTION_PRIORITY < USER_ALLOWLISTED_PRIORITY)
 
-        // Smarter Encryption priority.
-        // Note: It's important that the Smarter Encryption rule priority is
-        //       higher than the priority for Tracker Blocking etc rules.
-        //       After a request is redirected to use HTTPS, the redirected
-        //       request will still match against other block/allow rules. But
-        //       after an allow rules matches a request, upgrade schema rules
-        //       will no longer have the opportunity to match.
-        assert.ok(SMARTER_ENCRYPTION_PRIORITY >
-                  TRACKER_ALLOWLIST_CEILING_PRIORITY)
-        assert.ok(SMARTER_ENCRYPTION_PRIORITY >
-                 AD_ATTRIBUTION_POLICY_PRIORITY)
-        assert.ok(SMARTER_ENCRYPTION_PRIORITY >
-                  CONTENT_BLOCKING_ALLOWLIST_PRIORITY)
-
-        // Unprotected Temporary allowlist and user allowlist should disable all
-        // protections. All protections should also be disabled for
-        // ServiceWorker initiated requests.
-        assert.ok(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY >
-                  TRACKER_BLOCKING_CEILING_PRIORITY)
-        assert.ok(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY >
-                  SMARTER_ENCRYPTION_PRIORITY)
-        assert.ok(USER_ALLOWLISTED_PRIORITY >
-                  GPC_HEADER_PRIORITY)
-        assert.ok(USER_ALLOWLISTED_PRIORITY >
-                  TRACKING_PARAM_PRIORITY)
-        assert.ok(USER_ALLOWLISTED_PRIORITY ===
-                  UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY)
-        assert.ok(USER_ALLOWLISTED_PRIORITY ===
-                  SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY)
+        // The unprotectedTemporary allowlist, exception for ServiceWorker
+        // initiated requests and the user allowlist should take priority over
+        // everything else.
+        assert.equal(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY, SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY)
+        assert.equal(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY, USER_ALLOWLISTED_PRIORITY)
+        assert.ok(USER_ALLOWLISTED_PRIORITY > TRACKER_BLOCKING_CEILING_PRIORITY)
+        assert.ok(USER_ALLOWLISTED_PRIORITY > TRACKER_ALLOWLIST_CEILING_PRIORITY)
+        assert.ok(USER_ALLOWLISTED_PRIORITY > AD_ATTRIBUTION_POLICY_PRIORITY)
+        assert.ok(USER_ALLOWLISTED_PRIORITY > CONTENT_BLOCKING_ALLOWLIST_PRIORITY)
+        assert.ok(USER_ALLOWLISTED_PRIORITY > GPC_HEADER_PRIORITY)
+        assert.ok(USER_ALLOWLISTED_PRIORITY > TRACKING_PARAM_PRIORITY)
+        assert.ok(USER_ALLOWLISTED_PRIORITY > SMARTER_ENCRYPTION_PRIORITY)
     })
 })


### PR DESCRIPTION
We recently realised[1] that some relative rule priorities weren't
correct. For example, the contentBlocking allowlist was not taking
priority over the tracker blocking allowlist. While discussing those
relative priorities, we agreed it would be nice to have a better
overview of them all too.

So let's adjust some of the rule priorities here, and also take care
to expand the rule priority tests to provide more of an overview.

1 - https://github.com/duckduckgo/ddg2dnr/pull/49#discussion_r1035658292