### PR TITLE
Add basic support for AMP link protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ npm run extension-configuration ../extension-config-input.json \
         ../extension-configuration-ruleset-output.json [../match-details-by-rule-id-output.json]
 ```
 
-Note:
- - Extension configuration ruleset generation is a work in progress. So far,
-   only the tracker allowlist is supported.
-
 ## Development
 
 Lint the code:

--- a/lib/ampProtection.js
+++ b/lib/ampProtection.js
@@ -1,0 +1,75 @@
+/** @module tds */
+
+const {
+    generateDNRRule
+} = require('./utils')
+
+const AMP_PROTECTION_PRIORITY = 40000
+
+/**
+ * @typedef generateAmpProtectionRulesResult
+ * @property {import('./utils').DNRRule} rule
+ * @property {object} matchDetails
+ */
+
+/**
+ * Function to produce the declarativeNetRequest rules and corresponding match
+ * details for the given trackerAllowlist configuration.
+ * @param {object} extensionConfiguration
+ *   The extension configuration.
+ * @param {function} isRegexSupported
+ *   A function compatible with chrome.declarativeNetRequest.isRegexSupported.
+ *   See https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#method-isRegexSupported
+ * @return {Promise<generateAmpProtectionRulesResult[]>}
+ */
+async function generateAmpProtectionRules ({ features: { ampLinks } }, isRegexSupported) {
+    const results = []
+
+    if (!ampLinks ||
+        ampLinks.state !== 'enabled' ||
+        !ampLinks.settings ||
+        !ampLinks.settings.linkFormats ||
+        ampLinks.settings.linkFormats.length === 0) {
+        return results
+    }
+
+    const { settings: { linkFormats: ampLinkRegexps } } = ampLinks
+    const excludedDomains =
+        (ampLinks?.exceptions || []).map(({ domain }) => domain)
+
+    for (const ampLinkRegex of ampLinkRegexps) {
+        // It seems that \S (non-whitespace character class) is not always
+        // matched correctly. Luckily whitespace in URLs should be encoded
+        // anyway, so let's match . (any character) instead.
+        // TODO: Figure out minimal test case and file a Chromium bug.
+        const regexFilter = ampLinkRegex.replaceAll('\\S', '.')
+
+        const { isSupported } = await isRegexSupported({
+            regex: regexFilter,
+            isCaseSensitive: false,
+            requireCapturing: true
+        })
+        if (!isSupported) {
+            continue
+        }
+
+        const rule = generateDNRRule({
+            priority: AMP_PROTECTION_PRIORITY,
+            actionType: 'redirect',
+            regexFilter,
+            redirect: { regexSubstitution: 'https://\\1' },
+            resourceTypes: ['main_frame'],
+            excludedInitiatorDomains: excludedDomains,
+            excludedRequestDomains: excludedDomains
+        })
+        const matchDetails = {
+            type: 'ampProtection'
+        }
+        results.push({ rule, matchDetails })
+    }
+
+    return results
+}
+
+exports.AMP_PROTECTION_PRIORITY = AMP_PROTECTION_PRIORITY
+exports.generateAmpProtectionRules = generateAmpProtectionRules

--- a/lib/extensionConfiguration.js
+++ b/lib/extensionConfiguration.js
@@ -1,5 +1,6 @@
 /** @module extensionConfiguration */
 
+const { generateAmpProtectionRules } = require('./ampProtection')
 const { generateTrackerAllowlistRules } = require('./trackerAllowlist')
 const { generateTemporaryAllowlistRules } = require('./temporaryAllowlist')
 const { generateGPCheaderRules } = require('./gpc')
@@ -40,6 +41,12 @@ async function generateExtensionConfigurationRuleset (
             ruleset.push(rule)
             matchDetailsByRuleId[rule.id] = matchDetails
         }
+    }
+
+    // AMP link protection.
+    for (const result of
+        await generateAmpProtectionRules(extensionConfig, isRegexSupported)) {
+        appendRuleResult(result)
     }
 
     // Tracker Allowlist.

--- a/test/ampProtection.js
+++ b/test/ampProtection.js
@@ -1,0 +1,148 @@
+const assert = require('assert')
+
+const {
+    AMP_PROTECTION_PRIORITY
+} = require('../lib/ampProtection')
+
+const {
+    generateExtensionConfigurationRuleset
+} = require('../lib/extensionConfiguration')
+
+const baseExtensionConfigStringified = JSON.stringify({
+    features: {
+        ampLinks: {
+            state: 'enabled',
+            exceptions: [
+                {
+                    domain: 'exception1.example',
+                    reason: 'Reason 1'
+                },
+                {
+                    domain: 'exception2.example',
+                    reason: 'Reason 2'
+                }
+            ],
+            settings: {
+                linkFormats: [
+                    '^https?:\\/\\/(?:w{3}\\.)?google\\.\\S{2,}\\/amp\\/s\\/(\\S+)$',
+                    '^https?:\\/\\/\\S+ampproject\\.org\\/\\S\\/s\\/(\\S+)$'
+                ],
+                // Ignored for now.
+                deepExtractionEnabled: true,
+                deepExtractionTimeout: 1500,
+                keywords: [
+                    '=amp',
+                    'amp=',
+                    '&amp',
+                    'amp&',
+                    '/amp',
+                    'amp/',
+                    '.amp',
+                    'amp.',
+                    '%amp',
+                    'amp%',
+                    '_amp',
+                    'amp_',
+                    '?amp'
+                ]
+            }
+        }
+    }
+})
+
+async function isRegexSupportedTrue ({ regex, isCaseSensitive }) {
+    return { isSupported: true }
+}
+
+async function isRegexSupportedFalse ({ regex, isCaseSensitive }) {
+    return { isSupported: false }
+}
+
+async function rulesetEqual (
+    extensionConfig, isRegexSupported, expectedRuleset, expectedLookup
+) {
+    const extensionConfigBefore = JSON.stringify(extensionConfig)
+
+    const {
+        ruleset: actualRuleset,
+        matchDetailsByRuleId: actualLookup
+    } = await generateExtensionConfigurationRuleset(
+        extensionConfig, [], isRegexSupported
+    )
+
+    assert.deepEqual(actualRuleset, expectedRuleset)
+    assert.deepEqual(actualLookup, expectedLookup)
+
+    // Verify the extension config wasn't mutated.
+    assert.deepEqual(extensionConfig, JSON.parse(extensionConfigBefore))
+}
+
+describe('AMP link protection', () => {
+    it('should not generate AMP protection rules if disabled', async () => {
+        const extensionConfig = JSON.parse(baseExtensionConfigStringified)
+        extensionConfig.features.ampLinks.state = 'disabled'
+
+        await rulesetEqual(extensionConfig, isRegexSupportedTrue, [], {})
+    })
+
+    it('should skip unsupported regexFilters', async () => {
+        const extensionConfig = JSON.parse(baseExtensionConfigStringified)
+
+        await rulesetEqual(extensionConfig, isRegexSupportedFalse, [], {})
+    })
+
+    it('should generate AMP protection rules correctly', async () => {
+        const extensionConfig = JSON.parse(baseExtensionConfigStringified)
+
+        await rulesetEqual(extensionConfig, isRegexSupportedTrue,
+            [
+                {
+                    id: 1,
+                    priority: AMP_PROTECTION_PRIORITY,
+                    action: {
+                        type: 'redirect',
+                        redirect: { regexSubstitution: 'https://\\1' }
+                    },
+                    condition: {
+                        isUrlFilterCaseSensitive: false,
+                        regexFilter: '^https?:\\/\\/(?:w{3}\\.)?google\\..{2,}\\/amp\\/s\\/(.+)$',
+                        resourceTypes: ['main_frame'],
+                        excludedInitiatorDomains: [
+                            'exception1.example',
+                            'exception2.example'
+                        ],
+                        excludedRequestDomains: [
+                            'exception1.example',
+                            'exception2.example'
+                        ]
+                    }
+                },
+                {
+                    id: 2,
+                    priority: AMP_PROTECTION_PRIORITY,
+                    action: {
+                        type: 'redirect',
+                        redirect: { regexSubstitution: 'https://\\1' }
+                    },
+                    condition: {
+                        isUrlFilterCaseSensitive: false,
+                        regexFilter: '^https?:\\/\\/.+ampproject\\.org\\/.\\/s\\/(.+)$',
+                        resourceTypes: ['main_frame'],
+                        excludedInitiatorDomains: [
+                            'exception1.example',
+                            'exception2.example'
+                        ],
+                        excludedRequestDomains: [
+                            'exception1.example',
+                            'exception2.example'
+                        ]
+                    }
+                }
+            ],
+            {
+                1: { type: 'ampProtection' },
+                2: { type: 'ampProtection' }
+            }
+        )
+    })
+})

--- a/test/rulePriorities.js
+++ b/test/rulePriorities.js
@@ -5,6 +5,10 @@ const {
 } = require('../lib/smarterEncryption')
 
 const {
+    AMP_PROTECTION_PRIORITY
+} = require('../lib/ampProtection')
+
+const {
     GPC_HEADER_PRIORITY
 } = require('../lib/gpc')
 
@@ -46,6 +50,7 @@ describe('Rule Priorities', () => {
         assert.equal(TRACKER_ALLOWLIST_CEILING_PRIORITY, 20100)
         assert.equal(AD_ATTRIBUTION_POLICY_PRIORITY, 30000)
         assert.equal(CONTENT_BLOCKING_ALLOWLIST_PRIORITY, 30000)
+        assert.equal(AMP_PROTECTION_PRIORITY, 40000)
         assert.equal(GPC_HEADER_PRIORITY, 40000)
         assert.equal(TRACKING_PARAM_PRIORITY, 40000)
         assert.equal(COOKIE_PRIORITY, 40000)
@@ -91,9 +96,10 @@ describe('Rule Priorities', () => {
         assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY < SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY)
         assert.ok(AD_ATTRIBUTION_POLICY_PRIORITY < USER_ALLOWLISTED_PRIORITY)
 
-        // Tracking parameter protection and GPC should take priority over
-        // tracker blocking, the tracker allowlist and the contentBlocking
-        // allowlist, but not over the other features/allowlists.
+        // Tracking parameter protection, AMP protection  and GPC should take
+        // priority overtracker blocking, the tracker allowlist and the
+        // contentBlocking allowlist, but not over the other features/allowlists.
+        assert.equal(TRACKING_PARAM_PRIORITY, AMP_PROTECTION_PRIORITY)
         assert.equal(TRACKING_PARAM_PRIORITY, GPC_HEADER_PRIORITY)
         assert.ok(TRACKING_PARAM_PRIORITY > TRACKER_BLOCKING_CEILING_PRIORITY)
         assert.ok(TRACKING_PARAM_PRIORITY > TRACKER_ALLOWLIST_CEILING_PRIORITY)


### PR DESCRIPTION
The AMP link protection privacy feature redirects the user from AMP hosted pages[1] to the canonical source. It has two parts:

The AMP link protection privacy feature redirects the user from AMP
hosted pages[1] to the canonical source. It has two parts:

1. "Simple link redirection" - Redirect main_frame requests matching
   AMP regular expressions to strip the AMP prefix from the URL.
2. "1st party hosted AMP extraction" - Request the AMP URL in the
   background, extract the canonical URL from the DOM, redirect to the
   canonical URL.

So far, we're just implementing simple link redirection here. Also,
note that we can only (for now) support regular expressions containing
one capturing group that ends at the end of the regular expression.

1 - https://developers.google.com/amp