### PR TITLE
Refactor "Click to Load" handling

### DIFF
--- a/lib/tds.js
+++ b/lib/tds.js
@@ -9,19 +9,12 @@ const {
     generateRequestDomainsByTrackerDomain
 } = require('./utils')
 
-// Custom actions support features like click-to-load, allowing for rules that
-// are defined by the regular TDS and applied by the main blocking ruleset,
-// but also allow for an opposite rule to be applied to nullify / modify that rule.
-// For example, for click-to-load we need to block and redirect certain requests by
-// default, then allow those requests for a given tab if the user wants to reveal
-// something that was blocked
-
-// This map describes the currently supported custom actions and their corresponding
-// DNR action (and inverse)
-const supportedCustomActions = new Map([
-    ['block-ctl-yt', { action: 'block', inverseAction: 'allow' }],
-    ['block-ctl-fb', { action: 'block', inverseAction: 'allow' }]
-])
+// Tracker entry rules with an action starting with this prefix relate to the
+// "Click to Load" feature. The feature blocks third-party embedded content, but
+// provides the user an option to load the content again. To facilitate that,
+// both the blocking/redirecting declarativeNetRequest rules and inverse
+// allowing declarativeNetRequest rules are generated.
+const clickToLoadActionPrefix = 'block-ctl-'
 
 // Priority that the Tracker Blocking declarativeNetRequest rules start from.
 const BASELINE_PRIORITY = 10000
@@ -62,10 +55,13 @@ const MAXIMUM_REGEX_RULES = 900
 // During ruleset generation, the trackerDomain is stored with each
 // declarativeNetRequest rule to aid the creation of the trackerDomainByRuleId
 // lookup.
-// inverseCustomActionSymbol is used for keeping track of the inverse action rule for the
-// corresponding custom action rule
 const trackerDomainSymbol = Symbol('trackerDomain')
-const inverseCustomActionSymbol = Symbol('inverseCustomActionSymbol')
+
+// The special "Click to Load" action for a tracker entry rule is stored with
+// each blocking/redirection declarativeNetRequest rule generated for the
+// "Click to Load" feature. That way, an inverse allowing rule can be created
+// and stored for that action.
+const clickToLoadActionSymbol = Symbol('clickToLoadActionSymbol')
 
 function normalizeTypesCondition (types) {
     if (!types || types.length === 0) {
@@ -249,15 +245,20 @@ async function generateDNRRulesForTrackerEntry (
 
         ruleAction = normalizeAction(ruleAction, 'block')
 
-        // 'block' and 'allow' (aka 'ignore') actions are supported for tracker rules, also
-        // any custom rule mappings that are defined in supportedCustomActions
-        if (ruleAction !== 'block' && ruleAction !== 'allow' && !supportedCustomActions.has(ruleAction)) {
-            continue
+        // Handle the special "Click to Load" tracker entry rule actions. They
+        // act like other tracker entry rules with the 'block' action, except
+        // that their inverse allowing declarativeNetRequest rule is also
+        // generated.
+        let clickToLoadAction = null
+        if (ruleAction.startsWith(clickToLoadActionPrefix)) {
+            clickToLoadAction = ruleAction
+            ruleAction = 'block'
         }
 
-        const customRuleAction = supportedCustomActions.get(ruleAction)
-        if (customRuleAction) {
-            ruleAction = customRuleAction.action
+        // Only 'block', 'allow' (aka 'ignore') and "Click to Load" tracker
+        // entry rule actions are supported.
+        if (ruleAction !== 'block' && ruleAction !== 'allow') {
+            continue
         }
 
         trackerRule = normalizeTrackerRule(trackerRule)
@@ -307,28 +308,25 @@ async function generateDNRRulesForTrackerEntry (
 
         priority += TRACKER_RULE_PRIORITY_INCREMENT
 
-        const newRuleTemplate = {
-            priority,
-            actionType: ruleAction,
-            redirect: redirectAction,
-            urlFilter,
-            regexFilter,
-            matchCase,
-            requestDomains,
-            excludedInitiatorDomains,
-            resourceTypes
-        }
-        const newRule = generateDNRRule(newRuleTemplate)
+        {
+            const newRule = generateDNRRule({
+                priority,
+                actionType: ruleAction,
+                redirect: redirectAction,
+                urlFilter,
+                regexFilter,
+                matchCase,
+                requestDomains,
+                excludedInitiatorDomains,
+                resourceTypes
+            })
 
-        if (customRuleAction) {
-            // if a custom action, map the action to the specified default
-            // and add its inverse to the list of custom action rules
-            const inverseRule = { ...newRuleTemplate }
-            inverseRule.actionType = customRuleAction.inverseAction
-            newRule[inverseCustomActionSymbol] = { customAction: trackerEntryRules[i].action, ...generateDNRRule(inverseRule) }
-        }
+            if (clickToLoadAction) {
+                newRule[clickToLoadActionSymbol] = clickToLoadAction
+            }
 
-        dnrRules.push(newRule)
+            dnrRules.push(newRule)
+        }
 
         if (ruleExceptions &&
             (ruleAction === 'block' || ruleAction === 'redirect')) {
@@ -359,7 +357,7 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
     const trackerDomainsByRuleId = new Map()
     /** @type {import('./utils').MatchDetailsByRuleId} */
     const matchDetailsByRuleId = {}
-    const inverseCustomActionRules = {}
+    const allowingRulesByClickToLoadAction = {}
 
     // Combine similar rules and create the ruleset.
     const ruleset = []
@@ -369,36 +367,51 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
         const trackerDomain = rule[trackerDomainSymbol]
         delete rule[trackerDomainSymbol]
 
+        // If this is a "Click to Load" blocking/redirecting rule, take note of
+        // its inverse allowing rule and "Click to Load" action.
+        const clickToLoadAction = rule[clickToLoadActionSymbol]
+        delete rule[clickToLoadActionSymbol]
+        if (clickToLoadAction) {
+            // Create the inverse allowing rule. Note that domainType can be
+            // stripped since first-party requests are never blocked anyway.
+            const inverseAllowingRule = JSON.parse(JSON.stringify(rule))
+            inverseAllowingRule.action.type = 'allow'
+            delete inverseAllowingRule.action.redirect
+            delete inverseAllowingRule.condition.domainType
+
+            storeInLookup(
+                allowingRulesByClickToLoadAction,
+                clickToLoadAction,
+                [inverseAllowingRule]
+            )
+        }
+
         // Rules without a requestDomains condition definitely can't be
         // combined. Rules other than basic default allow/block almost never
-        // will be in practice. Surrogate script redirection rules can't be
-        // combined, nor rules with an inverse action, since the match details
-        // type is different. For those cases just add the rule to the ruleset
-        // and match details to the lookup now.
+        // will be in practice. Surrogate script redirection rules and "Click to
+        // Load" rules can't be combined since the match details type is
+        // different. For those cases just add the rule to the ruleset and match
+        // details to the lookup now.
         if (!rule.condition.requestDomains ||
             rule.priority !== BASELINE_PRIORITY ||
             rule.action === 'redirect' ||
-            rule[inverseCustomActionSymbol]) {
+            clickToLoadAction) {
             const ruleId = nextRuleId++
             rule.id = ruleId
-            if (rule[inverseCustomActionSymbol]) {
-                const inverseRule = rule[inverseCustomActionSymbol]
-                const customAction = inverseRule.customAction
-                delete inverseRule.customAction
-                if (inverseCustomActionRules[customAction]) {
-                    inverseCustomActionRules[customAction].push(inverseRule)
-                } else {
-                    inverseCustomActionRules[customAction] = [inverseRule]
-                }
-                delete rule[inverseCustomActionSymbol]
-            }
             ruleset.push(rule)
+
+            let matchType = 'trackerBlocking'
+            if (clickToLoadAction) {
+                matchType = 'clickToLoad'
+            } else if (rule.action.type === 'redirect') {
+                matchType = 'surrogateScript'
+            }
+
             matchDetailsByRuleId[ruleId] = {
-                type: rule.action.type === 'redirect'
-                    ? 'surrogateScript'
-                    : 'trackerBlocking',
+                type: matchType,
                 possibleTrackerDomains: [trackerDomain]
             }
+
             continue
         }
 
@@ -450,7 +463,7 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
         }
     }
 
-    return { ruleset, matchDetailsByRuleId, inverseCustomActionRules }
+    return { ruleset, matchDetailsByRuleId, allowingRulesByClickToLoadAction }
 }
 
 /**
@@ -459,8 +472,8 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
  *   The generated Tracker Blocking declarativeNetRequest ruleset.
  * @property {object} matchDetailsByRuleId
  *   Rule ID -> match details.
- * @property {object} inverseCustomActionRules
- *   array of inverse rules derived from custom action rules, as defined in supportedCustomActions
+ * @property {object} allowingRulesByClickToLoadAction
+ *   Inverse allowing declarativeNetRequest rules by "Click to Load" action.
  */
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -103,7 +103,7 @@ const regularExpressionChars = new Set(
     ['.', '*', '+', '?', '{', '}', '[', ']', '{', '}']
 )
 
-function storeInLookup (lookup, key, values) {
+function storeInMapLookup (lookup, key, values) {
     let storedValues = lookup.get(key)
     if (!storedValues) {
         storedValues = []
@@ -111,6 +111,36 @@ function storeInLookup (lookup, key, values) {
     }
     for (const value of values) {
         storedValues.push(value)
+    }
+}
+
+function storeInObjectLookup (lookup, key, values) {
+    let storedValues = lookup[key]
+    if (!storedValues) {
+        storedValues = []
+        lookup[key] = storedValues
+    }
+    for (const value of values) {
+        storedValues.push(value)
+    }
+}
+
+/**
+ * Stores the given values in the given lookup for the given key. Takes care to
+ * create the values array for the key if it doesn't already exist. Handles both
+ * Maps and raw Objects.
+ * Note: If lookup is a raw Object, the key will be treated as a string. Provide
+ *       a string for such keys, or a value that can be sensibly converted to
+ *       one.
+ * @param {Map|Object} lookup
+ * @param {any} key
+ * @param {any[]} values
+ */
+function storeInLookup (lookup, key, values) {
+    if (lookup instanceof Map) {
+        storeInMapLookup(lookup, key, values)
+    } else {
+        storeInObjectLookup(lookup, key, values)
     }
 }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,8 +2,42 @@ const assert = require('assert')
 
 const {
     generateDNRRule,
-    generateRequestDomainsByTrackerDomain
+    generateRequestDomainsByTrackerDomain,
+    storeInLookup
 } = require('../lib/utils')
+
+describe('storeInLookup', () => {
+    it('should work with Map lookups correctly', () => {
+        const lookup = new Map()
+        // Non-string key.
+        storeInLookup(lookup, 10, ['foo', 'bar'])
+        storeInLookup(lookup, 10, ['hello'])
+        storeInLookup(lookup, 10, ['world'])
+        // String key
+        storeInLookup(lookup, '10', [20])
+
+        // Map lookup should not be treated as vanilla Object.
+        assert.equal(Object.prototype.hasOwnProperty.call(lookup, '10'), false)
+        // Both the 10 and '10' keys should be set.
+        assert.deepEqual(lookup.get(10), ['foo', 'bar', 'hello', 'world'])
+        assert.deepEqual(lookup.get('10'), [20])
+    })
+
+    it('should work with vanilla Object lookups correctly', () => {
+        const lookup = Object.create(null)
+        // Non-string key.
+        storeInLookup(lookup, 10, ['foo', 'bar'])
+        storeInLookup(lookup, 10, ['hello'])
+        storeInLookup(lookup, 10, ['world'])
+        // String key
+        storeInLookup(lookup, '10', [20])
+
+        // Values should be combined, since keys are treated as strings for
+        // vanilla Objects.
+        assert.equal(Object.prototype.hasOwnProperty.call(lookup, '10'), true)
+        assert.deepEqual(lookup['10'], ['foo', 'bar', 'hello', 'world', 20])
+    })
+})
 
 describe('generateDNRRule', () => {
     it('should populate the rule priority', async () => {


### PR DESCRIPTION
For "Click to Load" tracker entry rules, we produce both the original
blocking/redirection declarativeNetRequest rule and the inverse
allowing declarativeNetRequest rule. Refactor the code used to
generate the inverse rules:
 - Instead of hardcoding all of the custom 'block-ctl-*' tracker entry
   rule actions, let's only hardcode the 'block-ctl-' prefix. That
   way, the extension can decide which "Click to Load"
   declarativeNetRequest rules should be disabled by default (by
   enabling the inverse allowing rules by default). In turn, that
   means the extension configuration can be used to specify which
   "Click to Load" rules in the block list should be applied.
 - Expand storeInLookup to support raw Object lookups and use that for
   the generation of the "Click to Load" allowing rule lookup.
 - Take care to provide the proper 'clickToLoad' match type for "Click
   to Load" rules.
 - Rename `inverseCustomActionRules` to the more descriptive
   `allowingRulesByClickToLoadAction`.
 - Improve some of the corresponding code comments and logic.
