### PR TITLE
Remove version from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "packages": {
         "": {
             "name": "@duckduckgo/ddg2dnr",
-            "version": "0.3.1",
             "license": "Apache-2.0",
             "bin": {
                 "ddg2dnr": "cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
     "name": "@duckduckgo/ddg2dnr",
-    "version": "0.3.1",
     "description": "Scripts to generate declarativeNetRequest rulesets for the DuckDuckGo Privacy Essentials extension",
     "license": "Apache-2.0",
     "repository": "duckduckgo/ddg2dnr",


### PR DESCRIPTION
Let's remove the version number from package.json, Git tags are enough
anyway. This should clear the way to use the GitHub UI for future
releases.
