### PR TITLE
Simplify Click to Load allowing rules further

### DIFF
--- a/lib/tds.js
+++ b/lib/tds.js
@@ -372,12 +372,14 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
         const clickToLoadAction = rule[clickToLoadActionSymbol]
         delete rule[clickToLoadActionSymbol]
         if (clickToLoadAction) {
-            // Create the inverse allowing rule. Note that domainType can be
-            // stripped since first-party requests are never blocked anyway.
+            // Create the inverse allowing rule. Note that domainType and
+            // excludedInitiatorDomains conditions can be stripped since
+            // first-party requests are never blocked anyway.
             const inverseAllowingRule = JSON.parse(JSON.stringify(rule))
             inverseAllowingRule.action.type = 'allow'
             delete inverseAllowingRule.action.redirect
             delete inverseAllowingRule.condition.domainType
+            delete inverseAllowingRule.condition.excludedInitiatorDomains
 
             storeInLookup(
                 allowingRulesByClickToLoadAction,

--- a/test/tds.js
+++ b/test/tds.js
@@ -1602,6 +1602,7 @@ describe('generateTdsRuleset', () => {
                 exceptions: { types: ['script'] }
             }
         ])
+        addDomain(blockList, 'another-default-block.invalid', 'Default Block entity', 'block')
 
         await rulesetEqual(blockList, isRegexSupportedTrue, null, {
             expectedRuleset: [
@@ -1684,8 +1685,14 @@ describe('generateTdsRuleset', () => {
                         type: 'block'
                     },
                     condition: {
-                        domainType: 'thirdParty',
-                        requestDomains: ['default-block.invalid']
+                        excludedInitiatorDomains: [
+                            'default-block.invalid',
+                            'another-default-block.invalid'
+                        ],
+                        requestDomains: [
+                            'default-block.invalid',
+                            'another-default-block.invalid'
+                        ]
                     }
                 },
                 {
@@ -1709,7 +1716,10 @@ describe('generateTdsRuleset', () => {
                     condition: {
                         urlFilter: '||default-block.invalid/known-action-2',
                         isUrlFilterCaseSensitive: false,
-                        domainType: 'thirdParty'
+                        excludedInitiatorDomains: [
+                            'default-block.invalid',
+                            'another-default-block.invalid'
+                        ]
                     }
                 },
                 {
@@ -1736,7 +1746,10 @@ describe('generateTdsRuleset', () => {
                     condition: {
                         urlFilter: '||default-block.invalid/block-ctl-fb-1',
                         isUrlFilterCaseSensitive: false,
-                        domainType: 'thirdParty',
+                        excludedInitiatorDomains: [
+                            'default-block.invalid',
+                            'another-default-block.invalid'
+                        ],
                         resourceTypes: ['script']
                     }
                 },
@@ -1749,7 +1762,10 @@ describe('generateTdsRuleset', () => {
                     condition: {
                         urlFilter: '||default-block.invalid/known-action-1',
                         isUrlFilterCaseSensitive: false,
-                        domainType: 'thirdParty'
+                        excludedInitiatorDomains: [
+                            'default-block.invalid',
+                            'another-default-block.invalid'
+                        ]
                     }
                 }
             ],
@@ -1811,7 +1827,10 @@ describe('generateTdsRuleset', () => {
                 },
                 7: {
                     type: 'trackerBlocking',
-                    possibleTrackerDomains: ['default-block.invalid']
+                    possibleTrackerDomains: [
+                        'default-block.invalid',
+                        'another-default-block.invalid'
+                    ]
                 },
                 8: {
                     type: 'trackerBlocking',


### PR DESCRIPTION
Click to Load allowing rules (like other allowing rules) don't need to
be limited to third-party matches. We already took care to remove
domainType conditions therefore, but we can also remove
excludedInitiatorDomains for when the allowed entity has multiple
associated domains.