### PR TITLE
Make the tds CLI easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,19 @@ npm run smarter-encryption ../list-of-domains-input.txt ../smarter-encryption-ru
 Generate the TDS ruleset:
 
 ```bash
-npm run tds ../tds-input.json ../supported-surrogates-input.json ../tds-ruleset-output.json \
+npm run tds ../tds-input.json analytics.js,ga.js,gpt.js ../tds-ruleset-output.json \
         [../match-details-by-rule-id-output.json]
 ```
 
 Note:
  - This includes both Tracker blocking (see [tds.json][3]) and
    "surrogate script" redirection. (see [tracker-surrogates][4]).
- - supported-surrogates-input.json must be a JSON encoded array of surrogate
-   script names.
+ - The second argument is a comma separated list of supported
+   surrogate scripts. Note that "analytics.js,ga.js,gpt.js" is
+   just an example, see the [tracker-surrogates][4] repository
+   for a full list of available surrogate scripts. If you don't
+   want to support any surrogate scripts, just use a placeholder
+   value e.g. "-".
 
 Generate the extension configuration ruleset:
 

--- a/cli.js
+++ b/cli.js
@@ -41,14 +41,14 @@ async function main () {
         if (args.length < 3 || args.length > 4) {
             console.error(
                 'Usage: npm run tds',
-                './tds-input.json ./supported-surrogates-input.json ',
+                './tds-input.json analytics.js,ga.js,gpt.js ',
                 './tds-ruleset-output.json ',
                 '[./match-details-by-rule-id-output.json]'
             )
         } else {
             const [
                 tdsFilePath,
-                supportedSurrogatesPath,
+                supportedSurrogates,
                 rulesetFilePath,
                 mappingFilePath
             ] = args
@@ -61,13 +61,7 @@ async function main () {
                       JSON.parse(
                           fs.readFileSync(tdsFilePath, { encoding: 'utf8' })
                       ),
-                      new Set(
-                          JSON.parse(
-                              fs.readFileSync(
-                                  supportedSurrogatesPath, { encoding: 'utf8' }
-                              )
-                          )
-                      ),
+                      new Set(supportedSurrogates.split(',')),
                       '/web_accessible_resources/',
                       isRegexSupported
                   )


### PR DESCRIPTION
When the CLI was originally designed, the idea was for a
configuration (either block list or extension configuration) to be the
input, and a ruleset to be the output. As we ported more features
however, that was slowly stretched by needing to pass in things like
the list of supported surrogate scripts and the list of user
"denylisted" domains.

Also, while the CLI is often useful during testing/development, it
hasn't been used as much more recently. That meant it has fallen
behind as we've made other changes. While it's still not a priority to
update, let's take a minute to at least make the list of supported
surrogate scripts easier to specify.
