### PR TITLE
Ensure combined ruleset generator handles missing features gracefully

### DIFF
--- a/lib/combined.js
+++ b/lib/combined.js
@@ -12,6 +12,13 @@ const { generateCookieBlockingRuleset } = require('./cookies')
  * @returns {import('./utils').RulesetResult}
  */
 function generateCombinedConfigBlocklistRuleset (tds, config, denylistedDomains, startingRuleId = 1) {
+    // Note: If more features are covered by the combined ruleset generator in
+    //       the future, this logic will need to be refactored. A pattern
+    //       similar to generateExtensionConfigurationRuleset could be used.
+    if (config.features?.cookie?.state !== 'enabled') {
+        return { ruleset: [], matchDetailsByRuleId: {} }
+    }
+
     // Merge cookie feature exceptions with unprotectedTemporary, then remove any denylisted domains
     const cookieAllowlist = (config.features.cookie?.exceptions.map(entry => entry.domain) || [])
         .concat(config.unprotectedTemporary.map(entry => entry.domain))

--- a/lib/extensionConfiguration.js
+++ b/lib/extensionConfiguration.js
@@ -68,7 +68,7 @@ async function generateExtensionConfigurationRuleset (
         appendRuleResult(result)
     }
 
-    if (extensionConfig.features.https?.exceptions?.length > 0) {
+    if (extensionConfig.features?.https?.exceptions?.length > 0) {
         appendRuleResult(createSmarterEncryptionTemporaryRule(extensionConfig.features.https.exceptions.map(entry => entry.domain)))
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,7 +33,7 @@
  * @typedef {object} PrivacyConfiguration
  * @property {PrivacyConfigDomainEntry[]} unprotectedTemporary
  * @property {{
- *  cookie: PrivacyConfigFeature<{
+ *  cookie?: PrivacyConfigFeature<{
  *      trackerCookie: string;
  *      nonTrackerCookie: string;
  *      excludedCookieDomains: PrivacyConfigDomainEntry[];

--- a/test/combined.js
+++ b/test/combined.js
@@ -1,0 +1,50 @@
+const assert = require('assert')
+
+const {
+    emptyBlockList
+} = require('./utils/helpers')
+const {
+    generateCombinedConfigBlocklistRuleset
+} = require('../lib/combined')
+
+describe('generateCombinedConfigBlocklistRuleset', () => {
+    it('should reject invalid extension configuration', () => {
+        assert.throws(() => {
+            generateCombinedConfigBlocklistRuleset(
+                // @ts-expect-error - Arguments invalid on purpose.
+                emptyBlockList(), null, []
+            )
+        })
+
+        assert.deepEqual(
+            generateCombinedConfigBlocklistRuleset(
+                // @ts-expect-error - Arguments invalid on purpose.
+                emptyBlockList(), { features: null }, []
+            ),
+            { ruleset: [], matchDetailsByRuleId: { } }
+        )
+
+        assert.deepEqual(
+            generateCombinedConfigBlocklistRuleset(
+                // @ts-expect-error - Arguments invalid on purpose.
+                emptyBlockList(), {}, []
+            ),
+            { ruleset: [], matchDetailsByRuleId: { } }
+        )
+
+        assert.deepEqual(
+            generateCombinedConfigBlocklistRuleset(
+                // @ts-expect-error - Arguments invalid on purpose.
+                emptyBlockList(), { features: { } }, []
+            ),
+            { ruleset: [], matchDetailsByRuleId: { } }
+        )
+
+        assert.deepEqual(
+            generateCombinedConfigBlocklistRuleset(
+                emptyBlockList(), { features: { }, unprotectedTemporary: [] }, []
+            ),
+            { ruleset: [], matchDetailsByRuleId: { } }
+        )
+    })
+})

--- a/test/tds.js
+++ b/test/tds.js
@@ -1,6 +1,9 @@
 const assert = require('assert')
 
 const {
+    emptyBlockList
+} = require('./utils/helpers')
+const {
     BASELINE_PRIORITY,
     SUBDOMAIN_PRIORITY_INCREMENT,
     TRACKER_RULE_PRIORITY_INCREMENT,
@@ -16,15 +19,6 @@ const MAXIMUM_RULES_PER_DOMAIN = Math.floor(
 )
 
 const supportedSurrogateScripts = new Set(['supported.js', 'supported2.js'])
-
-function emptyBlockList () {
-    return {
-        cnames: {},
-        domains: {},
-        entities: {},
-        trackers: {}
-    }
-}
 
 async function isRegexSupportedTrue ({ regex, isCaseSensitive }) {
     return { isSupported: true }

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -1,0 +1,10 @@
+function emptyBlockList () {
+    return {
+        cnames: {},
+        domains: {},
+        entities: {},
+        trackers: {}
+    }
+}
+
+exports.emptyBlockList = emptyBlockList


### PR DESCRIPTION
The extension configuration might not contain the "cookie" or "https"
features, we should take care to check they exist before attempting to
use them. Otherwise, an exception will be thrown should either of
those features be removed.

While we're at it, let's add unit test coverage to ensure the combined
ruleset generator handles those features (or any features) being
missing from the configuration.