### PR TITLE
Support option rules

### DIFF
--- a/lib/tds.js
+++ b/lib/tds.js
@@ -240,6 +240,7 @@ async function generateDNRRulesForTrackerEntry (
             action: ruleAction,
             rule: trackerRule,
             exceptions: ruleExceptions,
+            options: ruleOptions,
             surrogate
         } = trackerEntryRules[i]
 
@@ -308,6 +309,14 @@ async function generateDNRRulesForTrackerEntry (
 
         priority += TRACKER_RULE_PRIORITY_INCREMENT
 
+        // Handle initiator domains for option site blocking
+        let initiatorDomains = null
+        if (ruleOptions &&
+            (ruleAction === 'block' || ruleAction === 'redirect')) {
+                resourceTypes = normalizeTypesCondition(ruleOptions.types)
+                initiatorDomains = ruleOptions.domains
+        }
+
         {
             const newRule = generateDNRRule({
                 priority,
@@ -318,6 +327,7 @@ async function generateDNRRulesForTrackerEntry (
                 matchCase,
                 requestDomains,
                 excludedInitiatorDomains,
+                initiatorDomains,
                 resourceTypes
             })
 
@@ -346,7 +356,10 @@ async function generateDNRRulesForTrackerEntry (
                 initiatorDomains: ruleExceptions.domains
             }))
         }
+
     }
+
+    console.log(JSON.stringify(dnrRules, null, 4))
 
     return removeRedundantDNRRules(dnrRules)
 }

--- a/lib/tds.js
+++ b/lib/tds.js
@@ -309,7 +309,8 @@ async function generateDNRRulesForTrackerEntry (
 
         priority += TRACKER_RULE_PRIORITY_INCREMENT
 
-        // Handle initiator domains for option site blocking
+        // Handle option blocking rules. These rules turn blocking on
+        // only for listed domains and types.
         let initiatorDomains = null
         if (ruleOptions &&
             (ruleAction === 'block' || ruleAction === 'redirect')) {

--- a/lib/tds.js
+++ b/lib/tds.js
@@ -313,10 +313,9 @@ async function generateDNRRulesForTrackerEntry (
         let initiatorDomains = null
         if (ruleOptions &&
             (ruleAction === 'block' || ruleAction === 'redirect')) {
-                resourceTypes = normalizeTypesCondition(ruleOptions.types)
-                initiatorDomains = ruleOptions.domains
+            resourceTypes = normalizeTypesCondition(ruleOptions.types)
+            initiatorDomains = ruleOptions.domains
         }
-
         {
             const newRule = generateDNRRule({
                 priority,
@@ -356,10 +355,7 @@ async function generateDNRRulesForTrackerEntry (
                 initiatorDomains: ruleExceptions.domains
             }))
         }
-
     }
-
-    console.log(JSON.stringify(dnrRules, null, 4))
 
     return removeRedundantDNRRules(dnrRules)
 }

--- a/lib/tds.js
+++ b/lib/tds.js
@@ -309,7 +309,7 @@ async function generateDNRRulesForTrackerEntry (
 
         priority += TRACKER_RULE_PRIORITY_INCREMENT
 
-        // Handle option blocking rules. These rules turn blocking on
+        // Handle tracker entry rules with 'options'. These rules turn blocking on
         // only for listed domains and types.
         let initiatorDomains = null
         if (ruleOptions &&

--- a/test/tds.js
+++ b/test/tds.js
@@ -125,6 +125,8 @@ async function rulesetEqual (tds, isRegexSupported, startingRuleId, {
         )
     }
 
+    console.log(JSON.stringify(result, null, 2))
+
     assert.deepEqual(stringifyBlocklist(tds), tdsBefore, 'TDS mutated!')
     if (expectedRuleset) {
         /** @type {any} */
@@ -952,6 +954,68 @@ describe('generateTdsRuleset', () => {
                         initiatorDomains: [
                             'allowed.invalid'
                         ]
+                    }
+                }
+            ]
+        })
+    })
+
+    it('should handle block rules with options', async () => {
+        const blockList = emptyBlockList()
+        addDomain(blockList, 'block.invalid', 'Example entity', 'ignore', [
+            {
+                rule: 'block\\.invalid\\/domain',
+                options: { domains: ['block-this-domain.invalid'] }
+            },
+            {
+                rule: 'block\\.invalid\\/image',
+                options: { types: ['image'] }
+            }
+        ])
+
+            /*
+            {
+                rule: 'block\\.invalid\\/images',
+                options: { types: ['image'] }
+            }
+            {
+                rule: 'block\\.invalid\\/scripts',
+                exceptions: {
+                    domains: ['block-this-domain.invalid'],
+                    types: ['script']
+                }
+            }
+        ])
+*/
+
+        await rulesetEqual(blockList, isRegexSupportedTrue, null, {
+            expectedRuleset: [
+                {
+                    id: 1,
+                    priority: BASELINE_PRIORITY + TRACKER_RULE_PRIORITY_INCREMENT,
+                    action: {
+                        type: 'block'
+                    },
+                    condition: {
+                        initiatorDomains: [
+                            'block-this-domain.invalid'
+                        ],
+                        domainType: 'thirdParty',
+                        isUrlFilterCaseSensitive: false,
+                        urlFilter: '||block.invalid/domain'
+                    }
+                },
+                {
+                    id: 2,
+                    priority: BASELINE_PRIORITY + (TRACKER_RULE_PRIORITY_INCREMENT * 2),
+                    action: {
+                        type: 'block'
+                    },
+                    condition: {
+                        resourceTypes: ['image'],
+                        domainType: 'thirdParty',
+                        isUrlFilterCaseSensitive: false,
+                        urlFilter: '||block.invalid/image'
                     }
                 }
             ]


### PR DESCRIPTION
Adding support for option rules. 
- [Reference tests](https://github.com/duckduckgo/privacy-reference-tests/pull/76) for option rules
- [Updated docs](https://github.com/duckduckgo/tracker-blocklists/pull/8) with example and implementation guidelines

Option rules act like a normal block rule in MV3, we just need to set the initiatorDomains and resourceTypes. 

Testing
- `npm run test` to run privacy reference tests. Make sure you have the options tests in the linked PR above
- Test Page
    - Build the MV3 extension using this test blocklist https://staticcdn.duckduckgo.com/trackerblocking/beta/tds-options.json
    - Go to http://privacy-test-pages.glitch.me/tracker-site-blocking/index.html and run the tests. You can also check the extension devtools to see that the correct rule is matching on each page. 