### PR TITLE
Align linting config with the extension and fix failures

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,9 @@
 {
-    "extends": "standard",
+    "extends": ["standard", "eslint:recommended"],
     "rules": {
         "indent": ["error", 4],
-        "generator-star-spacing": ["error", {"before": false, "after": true}]
+        "generator-star-spacing": ["error", {"before": false, "after": true}],
+        "no-shadow": "error"
     },
     "env": {
         "webextensions": true,

--- a/lib/tds.js
+++ b/lib/tds.js
@@ -292,9 +292,9 @@ async function generateDNRRulesForTrackerEntry (
         // Handle "surrogate script" redirections.
         let redirectAction = null
         /** @type {import('./utils.js').ResourceType[]|null} */
-        let resourceTypes = null
+        let ruleResourceTypes = null
         if (surrogate) {
-            resourceTypes = ['script']
+            ruleResourceTypes = ['script']
             if (!supportedSurrogateScripts.has(surrogate)) {
                 // Block requests if an unsupported surrogate script rule
                 // matches.
@@ -314,7 +314,7 @@ async function generateDNRRulesForTrackerEntry (
         let initiatorDomains = null
         if (ruleOptions &&
             (ruleAction === 'block' || ruleAction === 'redirect')) {
-            resourceTypes = normalizeTypesCondition(ruleOptions.types)
+            ruleResourceTypes = normalizeTypesCondition(ruleOptions.types)
             initiatorDomains = ruleOptions.domains
         }
         {
@@ -328,7 +328,7 @@ async function generateDNRRulesForTrackerEntry (
                 requestDomains,
                 excludedInitiatorDomains,
                 initiatorDomains,
-                resourceTypes
+                resourceTypes: ruleResourceTypes
             })
 
             if (clickToLoadAction) {

--- a/puppeteerInterface.js
+++ b/puppeteerInterface.js
@@ -56,11 +56,11 @@ class PuppeteerInterface {
      */
     async isRegexSupported (regexOptions) {
         await this.ready
-        return await this.backgroundWorker?.evaluate(regexOptions =>
+        return await this.backgroundWorker?.evaluate(options =>
             new Promise(
                 resolve => {
                     chrome.declarativeNetRequest.isRegexSupported(
-                        regexOptions, resolve
+                        options, resolve
                     )
                 }
             )
@@ -75,15 +75,15 @@ class PuppeteerInterface {
      */
     async addRules (rules) {
         await this.ready
-        await this.backgroundWorker?.evaluate(async rules => {
+        await this.backgroundWorker?.evaluate(async addRules => {
             await chrome.declarativeNetRequest.updateDynamicRules({
-                addRules: rules
+                addRules
             })
 
             if (typeof self.ruleById === 'undefined') {
                 self.ruleById = new Map()
             }
-            for (const rule of rules) {
+            for (const rule of addRules) {
                 self.ruleById.set(rule.id, rule)
             }
         }, rules)
@@ -98,9 +98,9 @@ class PuppeteerInterface {
      */
     async removeRules (rules) {
         await this.ready
-        await this.backgroundWorker?.evaluate(async rules => {
+        await this.backgroundWorker?.evaluate(async removeRules => {
             const ruleIds = []
-            for (const rule of rules) {
+            for (const rule of removeRules) {
                 if (typeof self.ruleById !== 'undefined') {
                     self.ruleById.delete(rule.id)
                 }
@@ -158,10 +158,10 @@ class PuppeteerInterface {
         await this.ready
         if (!this.backgroundWorker) return []
         return await this.backgroundWorker.evaluate(
-            async testRequest =>
+            async testRequestDetails =>
                 new Promise(resolve =>
                     chrome.declarativeNetRequest.testMatchOutcome(
-                        testRequest,
+                        testRequestDetails,
                         ({ matchedRules }) => {
                             resolve(
                                 matchedRules.map(

--- a/test/referenceTests.js
+++ b/test/referenceTests.js
@@ -26,9 +26,9 @@ function loadJSONFile (prefix, file) {
 
 function* testCases (referenceTests) {
     for (const {
-        name: testGroup, tests: testCases
+        name: testGroup, tests: testGroupTestCases
     } of Object.values(referenceTests)) {
-        for (const testCase of testCases) {
+        for (const testCase of testGroupTestCases) {
             const { exceptPlatforms } = testCase
             if (exceptPlatforms?.includes('web-extension-mv3')) {
                 continue


### PR DESCRIPTION
In preparation for merging this repo into the extension (https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/1806), we should make the linting config the same. We were missing the `no-shadow` eslint option. This PR adds that option and fixes the cases where we were shadowing variables in the codebase.